### PR TITLE
Enhancement/parameterize embed model size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+/.agent-shell/

--- a/PLAN-FOR-KG-EMBEDDING.md
+++ b/PLAN-FOR-KG-EMBEDDING.md
@@ -1,0 +1,307 @@
+Goal**
+
+Build graph-aware OMOP terminology embeddings that preserve strong lexical grounding while injecting semantic structure from:
+
+- `concept_synonym`
+- `concept_ancestor`
+- `concept_relationship`
+
+Use `omop-graph/` as a reusable graph/query layer where it helps, not as a dependency by default unless it materially simplifies the pipeline.
+
+**Recommended architecture**
+
+Start with a staged system, not a pure graph-embedding model.
+
+1. Base encoder
+   Fine-tune the same text embedding model family you already use for `omop-emb`.
+
+2. Training signal
+   Contrastive training over graph-derived positive and hard-negative pairs/triples.
+
+3. Retrieval
+   Continue using `omop-emb` with FAISS/HNSW for ANN search.
+
+4. Optional reranking later
+   Add graph-aware reranking after top-k retrieval if needed.
+
+That is the lowest-risk path and should integrate cleanly with the current project.
+
+**Core design**
+
+Represent each concept with a textual serialization, not just `concept_name`.
+
+Candidate serialized input:
+```text
+Name: <preferred concept_name>
+Vocabulary: <vocabulary_id>
+Domain: <domain_id>
+Synonyms: <top N synonyms>
+Parents: <top M direct parent names>
+Relations: <selected typed relation summaries>
+```
+
+Keep this configurable so you can ablate components.
+
+**Training data construction**
+
+Build a graph-aware training dataset with four pair classes.
+
+1. Synonym positives
+   Source: `concept_synonym`
+   Examples:
+   - preferred name <-> synonym
+   - synonym <-> synonym for same concept
+   Weight: highest
+
+2. Hierarchy positives
+   Source: `concept_ancestor`
+   Start with `min_levels_of_separation = 1`
+   Examples:
+   - parent <-> child
+   - child <-> parent
+   Weight: high but below synonym
+   Optional later:
+   - depth 2 positives with lower weight
+
+3. Typed relation positives
+   Source: `concept_relationship`
+   Restrict to semantically meaningful predicates only
+   Use `omop-graph` predicate typing to keep:
+   - `ONTOLOGICAL`
+   - maybe `MAPPING`
+   Exclude at first:
+   - `METADATA`
+   - noisy structural predicates unless explicitly justified
+
+4. Hard negatives
+   Important for terminology search quality
+   Construct from:
+   - lexical near-matches that are graph-distant
+   - same vocabulary/domain but not close in graph
+   - same parent but wrong branch
+   - current embedding top-k false positives
+
+This hard-negative set is where a lot of the value will come from.
+
+**Suggested loss**
+
+Phase 1:
+- Standard contrastive / multiple-negatives ranking loss
+
+Phase 2:
+- Weighted positives by edge type
+- Example weighting:
+  - synonym: 1.0
+  - parent-child: 0.7
+  - typed relation: 0.4 to 0.6
+  - depth-2 ancestor: 0.3
+
+Do not start with a complex custom graph loss unless needed.
+
+**What to reuse from `omop-graph`**
+
+Likely reusable immediately:
+- synonym lookup/query patterns
+  [omop-graph/src/omop_graph/graph/queries.py](/ai-agent/omop-emb/omop-graph/src/omop_graph/graph/queries.py:68)
+- ancestor/descendant queries
+  [omop-graph/src/omop_graph/graph/queries.py](/ai-agent/omop-emb/omop-graph/src/omop_graph/graph/queries.py:178)
+- predicate classification
+  [omop-graph/src/omop_graph/graph/edges.py](/ai-agent/omop-emb/omop-graph/src/omop_graph/graph/edges.py:35)
+- `KnowledgeGraph` facade if you want a cleaner graph API
+  [omop-graph/src/omop_graph/graph/kg.py](/ai-agent/omop-emb/omop-graph/src/omop_graph/graph/kg.py:53)
+
+Do not depend on `omop-graph` blindly. First decide:
+- copy/port selected query utilities into `omop-emb`
+- or add an optional extra for graph-aware training
+
+My bias:
+- reuse query logic and predicate typing patterns
+- keep training pipeline inside `omop-emb`
+- avoid making runtime search depend on `omop-graph`
+
+**Proposed repo additions**
+
+Add a new offline pipeline area, separate from CLI search:
+
+- `src/omop_emb/graph_training/`
+- `src/omop_emb/graph_training/extract.py`
+- `src/omop_emb/graph_training/serialize.py`
+- `src/omop_emb/graph_training/pairs.py`
+- `src/omop_emb/graph_training/hard_negatives.py`
+- `src/omop_emb/graph_training/train.py`
+- `src/omop_emb/graph_training/eval.py`
+
+Add scripts/CLI commands later if useful:
+- `omop-emb export-graph-training-data`
+- `omop-emb train-graph-aware-model`
+- `omop-emb eval-graph-aware-model`
+
+I would start with export + eval before adding train CLI polish.
+
+**Concrete implementation phases**
+
+1. Data extraction layer
+   Build reproducible exports from DB or local files:
+   - concept core fields
+   - synonyms
+   - depth-1 ancestors/descendants
+   - filtered typed relations
+
+   Output parquet/jsonl shards keyed by `concept_id`.
+
+2. Text serialization layer
+   Implement configurable concept-to-text rendering:
+   - preferred label only
+   - label + synonyms
+   - label + synonyms + parents
+   - label + selected relations
+
+   This lets you run ablations.
+
+3. Pair generation layer
+   Emit training examples with:
+   - `anchor_text`
+   - `positive_text`
+   - `negative_text` or candidate pool
+   - `pair_type`
+   - `weight`
+   - source metadata
+
+4. Hard-negative mining
+   Start simple:
+   - BM25/token overlap negatives
+   - current embedding false positives
+   - graph-distant lexical confounders
+
+5. Training loop
+   Fine-tune with sentence-transformers style contrastive training or equivalent.
+   Save model in a form usable by your embedding service.
+
+6. Evaluation harness
+   Measure:
+   - exact concept grounding accuracy @k
+   - synonym retrieval accuracy
+   - parent/child neighborhood quality
+   - graph-aware nearest-neighbor coherence
+   - latency/ANN impact after indexing with HNSW
+
+7. Integration back into `omop-emb`
+   Once a model is good:
+   - embed concepts with `omop-emb add-embeddings`
+   - use FAISS HNSW for search
+   - compare against current baseline
+
+**Evaluation plan**
+
+You need offline evaluation before rolling this into production.
+
+Build at least 4 eval sets:
+
+1. Exact synonym grounding
+   Query = synonym
+   Target = concept_id
+
+2. Lexical ambiguity set
+   Queries with confusing near-strings
+   Measure top-k accuracy and failure modes
+
+3. Hierarchy coherence
+   For each concept, nearest neighbors should include:
+   - same concept synonyms
+   - parent/child
+   - close descendants
+   more often than graph-distant lexical lookalikes
+
+4. Typed relation retrieval
+   If relation-aware training is used, test whether meaningful typed neighbors rise without harming lexical grounding
+
+Primary metrics:
+- recall@1, @5, @10
+- MRR
+- neighborhood purity by ancestor depth/domain/vocabulary
+- search latency with HNSW
+
+**Important modeling constraints**
+
+Do first:
+- synonyms
+- direct hierarchy
+- selected typed relations
+
+Do later:
+- full ancestor closure
+- deep graph message passing
+- metadata predicates
+
+Reason:
+Too much ancestor signal too early will oversmooth the space and hurt lexical specificity.
+
+**Concrete first experiment**
+
+Baseline experiment matrix:
+
+1. `label-only`
+2. `label + synonyms`
+3. `label + synonyms + direct parents`
+4. `label + synonyms + direct parents + selected relations`
+
+Train each with the same contrastive recipe.
+Compare on grounding accuracy and nearest-neighbor coherence.
+
+My expectation:
+`label + synonyms + direct parents` is likely the first strong win.
+
+**Potential future synergy with HNSW**
+
+If graph-aware training works, HNSW benefits indirectly because:
+- local neighborhoods in vector space become more semantically faithful
+- HNSW’s routing graph becomes better aligned with ontology structure
+- retrieval quality should improve at the same ANN settings
+
+But do not try to inject OMOP graph edges into HNSW itself initially.
+
+**Context for the next Codex session**
+
+Use this exact starting brief:
+
+> We are in `/ai-agent/omop-emb`. The project already supports FAISS HNSW and recently gained:
+> - `switch-index-type`
+> - HNSW metadata stored in `model_registry.details`
+> - improved FAISS rebuild progress logging
+>
+> There is also a temporary linked repo at `/ai-agent/omop-emb/omop-graph/` with useful graph query utilities over OMOP vocabulary tables.
+>
+> We want to implement the first stage of graph-aware terminology embedding training for OMOP concepts. The data sources are:
+> - `concept_synonym`
+> - `concept_ancestor`
+> - `concept_relationship`
+>
+> Desired approach:
+> - keep retrieval model text-first, not pure graph-only
+> - generate graph-derived contrastive training data
+> - start with synonyms, direct parent/child relations, and selected semantic relationships
+> - avoid noisy metadata relationships
+> - create an offline export/eval pipeline before any full training integration
+>
+> Please:
+> 1. inspect current repo structure and `omop-graph/`
+> 2. propose exact module/file additions under `src/omop_emb/graph_training/`
+> 3. implement phase 1 data extraction and pair generation
+> 4. add tests for pair generation logic
+> 5. document assumptions and output schema
+
+**Suggested first deliverable for that session**
+
+Implement only phase 1:
+
+- graph-training data export
+- text serialization
+- pair generation for:
+  - synonym positives
+  - parent-child positives
+  - selected typed relation positives
+- hard-negative scaffolding
+- tests
+- docs
+
+That is the right slice to build next.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Important:
 
 - `OMOP_DATABASE_URL` must point to the PostgreSQL database that exposes your
   OMOP vocabulary tables.
+- The CLI is intended to work against an existing OMOP database. It should not
+  attempt to create the full OMOP schema.
 - The code queries the OMOP `concept` table by ORM table name, not by a
   hard-coded schema-qualified path such as `vocabulary.concept`.
 - PostgreSQL resolves that table through the connection `search_path`. If your

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Important:
   is rebuilt cleanly.
 - The FAISS backend now supports `flat` and `hnsw` index types. `hnsw` is the
   better default for larger retrieval workloads.
+- With the FAISS backend, `add-embeddings` writes raw vectors to
+  `embeddings.h5`. Search indexes are separate metric-specific FAISS files such
+  as `flat_cosine_index.faiss` or `flat_l2_index.faiss` built from that HDF5
+  store.
+- When `--index-type hnsw` is used, the HNSW tuning parameters are stored in
+  the model registry metadata and reused for rebuilds and searches.
 - The code queries the OMOP `concept` table by ORM table name, not by a
   hard-coded schema-qualified path such as `vocabulary.concept`.
 - PostgreSQL resolves that table through the connection `search_path`. If your
@@ -74,6 +80,10 @@ Important:
   selected concepts may still be zero if the query resolves to the wrong table,
   the vocabulary filter matches nothing, or the model is already registered as
   embedded in the SQL registry.
+- `omop-emb search` defaults to cosine. If the corresponding FAISS index file
+  is missing, the system may build it lazily from `embeddings.h5` on first
+  search, which can be expensive for large stores. For predictable performance,
+  run `omop-emb rebuild-index` for the metric or metrics you intend to query.
 
 Stored embeddings can also be queried after ingestion:
 
@@ -97,6 +107,19 @@ omop-emb rebuild-index \
   --faiss-base-dir ./data \
   --metric-type cosine \
   --metric-type l2
+```
+
+Existing FAISS models can be switched from `flat` to `hnsw` without regenerating
+the raw HDF5 embeddings:
+
+```bash
+omop-emb switch-index-type \
+  --model my-embedding-model \
+  --backend faiss \
+  --index-type hnsw \
+  --hnsw-num-neighbors 48 \
+  --hnsw-ef-search 96 \
+  --hnsw-ef-construction 240
 ```
 
 ## DB Test Environment

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ omop-emb add-embeddings \
   --api-base http://localhost:8000/v1 \
   --embedding-path /embeddings \
   --backend faiss \
+  --index-type hnsw \
   --faiss-base-dir ./data \
   --model my-embedding-model \
   --embedding-dim 1024 \
@@ -61,6 +62,8 @@ Important:
   the existing backend storage and model registry entry before re-registering it.
   For FAISS, this also deletes the model's on-disk directory so the vector store
   is rebuilt cleanly.
+- The FAISS backend now supports `flat` and `hnsw` index types. `hnsw` is the
+  better default for larger retrieval workloads.
 - The code queries the OMOP `concept` table by ORM table name, not by a
   hard-coded schema-qualified path such as `vocabulary.concept`.
 - PostgreSQL resolves that table through the connection `search_path`. If your
@@ -83,6 +86,17 @@ omop-emb search "type 2 diabetes" \
   --faiss-base-dir ./data \
   --metric-type cosine \
   --k 5
+```
+
+FAISS indexes can also be rebuilt explicitly from the stored HDF5 vectors:
+
+```bash
+omop-emb rebuild-index \
+  --model my-embedding-model \
+  --backend faiss \
+  --faiss-base-dir ./data \
+  --metric-type cosine \
+  --metric-type l2
 ```
 
 ## DB Test Environment

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Example:
 ```bash
 omop-emb add-embeddings \
   --api-base http://localhost:8000/v1/embeddings \
-  --api-key <key> \
   --backend faiss \
   --faiss-base-dir ./data \
   --model my-embedding-model \
@@ -49,6 +48,7 @@ Important:
   OMOP vocabulary tables.
 - The CLI is intended to work against an existing OMOP database. It should not
   attempt to create the full OMOP schema.
+- `--api-key` is optional. Use it only if your embedding service expects bearer-token authentication.
 - `--api-base` should be the API base URL, for example `http://localhost:8000/v1`,
   not the full embeddings endpoint path. Use `--embedding-path` if your server
   expects a non-standard endpoint such as `/embed`.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Important:
   OMOP vocabulary tables.
 - The CLI is intended to work against an existing OMOP database. It should not
   attempt to create the full OMOP schema.
+- `--api-base` should be the API base URL, for example `http://localhost:8000/v1`,
+  not the full embeddings endpoint path. Use `--embedding-path` if your server
+  expects a non-standard endpoint such as `/embed`.
 - The code queries the OMOP `concept` table by ORM table name, not by a
   hard-coded schema-qualified path such as `vocabulary.concept`.
 - PostgreSQL resolves that table through the connection `search_path`. If your

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Embedding layer for OMOP CDM.
 can match the embedding backend you actually intend to use.
 
 ```bash
-pip install "omop-emb[postgres]"
+pip install "omop-emb[pgvector]"
 pip install "omop-emb[faiss]"
 pip install "omop-emb[all]"
 ```
 
 Notes:
 
-- `postgres` installs the PostgreSQL/pgvector dependencies.
+- `pgvector` installs the PostgreSQL/pgvector dependencies.
 - `faiss` installs the FAISS-based backend dependencies. This currently only includes CPU support
 - `all` installs both backend stacks for development or mixed environments.
 - A plain `pip install omop-emb` installs the shared core package only.
@@ -33,7 +33,8 @@ Example:
 
 ```bash
 omop-emb add-embeddings \
-  --api-base http://localhost:8000/v1/embeddings \
+  --api-base http://localhost:8000/v1 \
+  --embedding-path /embeddings \
   --backend faiss \
   --faiss-base-dir ./data \
   --model my-embedding-model \
@@ -46,6 +47,9 @@ Important:
 
 - `OMOP_DATABASE_URL` must point to the PostgreSQL database that exposes your
   OMOP vocabulary tables.
+- `OMOP_EMB_METADATA_SCHEMA` controls where `omop-emb` creates its own
+  `model_registry` and backend-specific metadata tables. The default is
+  `public`.
 - The CLI is intended to work against an existing OMOP database. It should not
   attempt to create the full OMOP schema.
 - `--api-key` is optional. Use it only if your embedding service expects bearer-token authentication.
@@ -55,6 +59,8 @@ Important:
 - If you need to change the registered dimensions or other model configuration
   for an existing model name, use `--overwrite-model-registration`. This deletes
   the existing backend storage and model registry entry before re-registering it.
+  For FAISS, this also deletes the model's on-disk directory so the vector store
+  is rebuilt cleanly.
 - The code queries the OMOP `concept` table by ORM table name, not by a
   hard-coded schema-qualified path such as `vocabulary.concept`.
 - PostgreSQL resolves that table through the connection `search_path`. If your
@@ -104,6 +110,20 @@ For non-admin testing against an existing database, set:
 In that mode, the suite does not create or drop databases or roles. It creates
 its tables inside the specified schema and forces the engine `search_path` into
 that schema so your existing OMOP tables are not touched.
+
+To run only non-database unit tests:
+
+```bash
+pytest -m unit
+```
+
+To run FAISS integration tests against an existing PostgreSQL database/schema:
+
+```bash
+TEST_DB_USE_EXISTING=1 \
+TEST_DB_SCHEMA=omop_emb_test \
+pytest -m "faiss and integration"
+```
 
 # Project Roadmap
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,51 @@ omop-emb search "type 2 diabetes" \
   --k 5
 ```
 
+For repeated queries against the same FAISS model, use one of the warm-process
+options instead of invoking `omop-emb search` once per shell command:
+
+- `omop-emb search-batch` runs many queries in one process from a text file.
+- `omop-emb serve-search` starts a small single-threaded HTTP service that
+  keeps the FAISS index loaded in memory.
+
+Example batch search:
+
+```bash
+omop-emb search-batch queries.tsv \
+  --api-base http://localhost:8000/v1 \
+  --embedding-path /embeddings \
+  --model my-embedding-model \
+  --backend faiss \
+  --faiss-base-dir ./data \
+  --metric-type cosine \
+  --k 5
+```
+
+Example search service:
+
+```bash
+omop-emb serve-search \
+  --api-base http://localhost:8000/v1 \
+  --embedding-path /embeddings \
+  --model my-embedding-model \
+  --backend faiss \
+  --faiss-base-dir ./data \
+  --metric-type cosine \
+  --host 127.0.0.1 \
+  --port 18080
+```
+
+Example request to the service:
+
+```bash
+curl -X POST http://127.0.0.1:18080/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query_id":"1","query_text":"type 2 diabetes","k":5}'
+```
+
+The current service implementation is intentionally single-threaded, so
+overlapping requests are queued and handled one at a time.
+
 FAISS indexes can also be rebuilt explicitly from the stored HDF5 vectors:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Important:
 - `--api-base` should be the API base URL, for example `http://localhost:8000/v1`,
   not the full embeddings endpoint path. Use `--embedding-path` if your server
   expects a non-standard endpoint such as `/embed`.
+- If you need to change the registered dimensions or other model configuration
+  for an existing model name, use `--overwrite-model-registration`. This deletes
+  the existing backend storage and model registry entry before re-registering it.
 - The code queries the OMOP `concept` table by ORM table name, not by a
   hard-coded schema-qualified path such as `vocabulary.concept`.
 - PostgreSQL resolves that table through the connection `search_path`. If your

--- a/README.md
+++ b/README.md
@@ -24,6 +24,40 @@ Notes:
 
 Extended documentation can be found [here](https://AustralianCancerDataNetwork.github.io/omop-emb).
 
+## Quick Start
+
+`omop-emb` reads OMOP concepts through SQLAlchemy and writes embedding metadata
+through PostgreSQL even when you use the `faiss` backend for vector storage.
+
+Example:
+
+```bash
+omop-emb add-embeddings \
+  --api-base http://localhost:8000/v1/embeddings \
+  --api-key <key> \
+  --backend faiss \
+  --faiss-base-dir ./data \
+  --model my-embedding-model \
+  --embedding-dim 1024 \
+  --vocabulary SNOMED \
+  --num-embeddings 500
+```
+
+Important:
+
+- `OMOP_DATABASE_URL` must point to the PostgreSQL database that exposes your
+  OMOP vocabulary tables.
+- The code queries the OMOP `concept` table by ORM table name, not by a
+  hard-coded schema-qualified path such as `vocabulary.concept`.
+- PostgreSQL resolves that table through the connection `search_path`. If your
+  OMOP vocabulary tables live in a non-default schema such as
+  `staging_vocabulary`, your `search_path` must include that schema or the
+  connection must otherwise resolve `concept` to the intended table.
+- If you pass `--num-embeddings`, that is only a limit. The actual number of
+  selected concepts may still be zero if the query resolves to the wrong table,
+  the vocabulary filter matches nothing, or the model is already registered as
+  embedded in the SQL registry.
+
 # Project Roadmap
 
 - [x] Interface for postgres storage of vectors

--- a/README.md
+++ b/README.md
@@ -66,6 +66,45 @@ Important:
   the vocabulary filter matches nothing, or the model is already registered as
   embedded in the SQL registry.
 
+Stored embeddings can also be queried after ingestion:
+
+```bash
+omop-emb search "type 2 diabetes" \
+  --api-base http://localhost:8000/v1 \
+  --embedding-path /embeddings \
+  --model my-embedding-model \
+  --backend faiss \
+  --faiss-base-dir ./data \
+  --metric-type cosine \
+  --k 5
+```
+
+## DB Test Environment
+
+The PostgreSQL-backed test suite reads these environment variables from
+`tests/conftest.py`:
+
+- `TEST_DB_HOST`: required, PostgreSQL host for the test database server.
+- `TEST_DB_PORT`: required, PostgreSQL port.
+- `TEST_DATABASE_NAME`: optional, defaults to `test_omop_emb`.
+- `TEST_DB_USERNAME`: optional, defaults to `test`.
+- `TEST_DB_PASSWORD`: optional, defaults to `test`.
+- `TEST_DB_DRIVER`: optional, defaults to `postgresql+psycopg2`.
+- `POSTGRES_USER`: optional, defaults to `postgres`; used for creating/dropping the test database.
+- `POSTGRES_PASSWORD`: optional, defaults to `postgres`; used for creating/dropping the test database.
+
+The tests create and drop a dedicated database and role, so the admin user must
+have permission to create roles and databases.
+
+For non-admin testing against an existing database, set:
+
+- `TEST_DB_USE_EXISTING=1`
+- `TEST_DB_SCHEMA=<dedicated_test_schema>`
+
+In that mode, the suite does not create or drop databases or roles. It creates
+its tables inside the specified schema and forces the engine `search_path` into
+that schema so your existing OMOP tables are not touched.
+
 # Project Roadmap
 
 - [x] Interface for postgres storage of vectors

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ The package currently supports:
 Install the backend you actually want to use:
 
 ```bash
-pip install "omop-emb[postgres]"
+pip install "omop-emb[pgvector]"
 pip install "omop-emb[faiss]"
 pip install "omop-emb[all]"
 ```
@@ -28,7 +28,7 @@ A plain `pip install omop-emb` installs only the shared core package.
 At runtime, backend choice should also be explicit. The intended direction is:
 
 - install-time choice via extras
-- runtime choice via config such as `OMOP_EMB_BACKEND=postgres` or `OMOP_EMB_BACKEND=faiss` or passing it as an argument to the respective interface (e.g. see [CLI reference](usage/cli.md))
+- runtime choice via config such as `OMOP_EMB_BACKEND=pgvector` or `OMOP_EMB_BACKEND=faiss` or passing it as an argument to the respective interface (e.g. see [CLI reference](usage/cli.md))
 
 
 !!! info "Important caveats"

--- a/docs/usage/backend-selection.md
+++ b/docs/usage/backend-selection.md
@@ -11,7 +11,9 @@ The current backend factory recognizes:
 - `pgvector`: The [pgvector](https://github.com/pgvector/pgvector) extension to a standard postgres database to store embeddings directly in the database.
 - `faiss`: The [FAISS](https://github.com/facebookresearch/faiss) storage solution for on-disk storage.
 
-The default backend name is currently `postgres`.
+The supported backend names are `pgvector` and `faiss`. There is no implicit
+default in the backend factory; callers must pass a backend explicitly or set
+`OMOP_EMB_BACKEND`.
 
 ## Runtime selection
 
@@ -23,7 +25,7 @@ The intended pattern is:
 Examples:
 
 ```bash
-export OMOP_EMB_BACKEND=postgres
+export OMOP_EMB_BACKEND=pgvector
 export OMOP_EMB_BACKEND=faiss
 ```
 
@@ -36,7 +38,7 @@ The backend factory lives in `omop_emb.backends`:
 ```python
 from omop_emb.backends import get_embedding_backend
 
-backend = get_embedding_backend("postgres")
+backend = get_embedding_backend("pgvector")
 backend = get_embedding_backend("faiss")
 ```
 
@@ -77,7 +79,7 @@ At the moment:
 
 - the backend abstraction and backend factory exist
 - PostgreSQL and FAISS backend classes exist
-- the production CLI path still targets the PostgreSQL embedding workflow
+- the CLI supports both `pgvector` and `faiss` backends via `--backend`
 - PostgreSQL-specific embedding dependencies are optional, but a database
   backend is still required for OMOP access and model registration
 - model registration is intended to remain shared and database-backed even when

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -55,7 +55,7 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 | **`--api-base`** | | `String` | **Required** | Base URL for the embedding API service, e.g. `http://localhost:8000/v1`. |
 | **`--embedding-path`** | | `String` | `/embeddings` or `OMOP_EMB_EMBEDDING_PATH` | Relative path for the embedding endpoint, e.g. `/embeddings` or `/embed`. |
 | **`--api-key`** | | `String` | `OMOP_EMB_API_KEY` or none | Optional API key for the embedding API provider. |
-| **`--index-type`** | | `IndexType` | `FLAT` | The storage index for the embeddings for retrieval. Currently supported: `FLAT`. |
+| **`--index-type`** | | `IndexType` | `FLAT` | The storage index for the embeddings for retrieval. FAISS supports `FLAT` and `HNSW`. |
 | **`--batch-size`** | `-b` | `Integer` | `100` | Number of concepts to process in each chunk. |
 | **`--model`** | `-m` | `String` | `OMOP_EMB_MODEL` or `text-embedding-3-small` | Name of the embedding model to use for generating vectors. |
 | **`--embedding-dim`** | | `Integer` | `OMOP_EMB_EMBEDDING_DIM` or auto-detect | Explicit embedding dimension override for models whose dimensions cannot be inferred automatically. |
@@ -100,6 +100,7 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 - If stale FAISS artifacts exist on disk without a matching SQL registration,
   the CLI now fails early and tells you to rerun with
   `--overwrite-model-registration`.
+- For larger FAISS stores, prefer `--index-type hnsw` over `flat`.
 
 ## `search`
 
@@ -124,3 +125,23 @@ selected model and backend.
 
 The output is tab-separated with `rank`, `concept_id`, `similarity`, and
 `concept_name`.
+
+## `rebuild-index`
+
+### Usage
+```bash
+omop-emb rebuild-index --model <MODEL> --backend faiss [OPTIONS]
+```
+
+This command rebuilds FAISS index files from the stored HDF5 vectors for an
+already registered model. It is useful after recovering from inconsistent local
+index files or when you want to materialize multiple metrics ahead of time.
+
+### Common options
+
+- `--model`: registered embedding model name.
+- `--backend`: currently only `faiss` supports explicit rebuild.
+- `--faiss-base-dir`: base directory containing the model's FAISS storage.
+- `--metric-type`: repeat to rebuild multiple metrics. If omitted, all metrics
+  supported by the model's index type are rebuilt.
+- `--batch-size`: streaming batch size used while rebuilding from HDF5.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -55,7 +55,7 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 | :--- | :--- | :--- | :--- | :--- |
 | **`--api-base`** | | `String` | **Required** | Base URL for the embedding API service, e.g. `http://localhost:8000/v1`. |
 | **`--embedding-path`** | | `String` | `/embeddings` or `OMOP_EMB_EMBEDDING_PATH` | Relative path for the embedding endpoint, e.g. `/embeddings` or `/embed`. |
-| **`--api-key`** | | `String` | **Required** | API key for the embedding API provider. |
+| **`--api-key`** | | `String` | `OMOP_EMB_API_KEY` or none | Optional API key for the embedding API provider. |
 | **`--index-type`** | | `IndexType` | `FLAT` | The storage index for the embeddings for retrieval. Currently supported: `FLAT`. |
 | **`--batch-size`** | `-b` | `Integer` | `100` | Number of concepts to process in each chunk. |
 | **`--model`** | `-m` | `String` | `OMOP_EMB_MODEL` or `text-embedding-3-small` | Name of the embedding model to use for generating vectors. |
@@ -71,6 +71,7 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 - `OMOP_DATABASE_URL`: database connection string for the OMOP store.
   The connection should resolve the OMOP `concept` table via PostgreSQL
   `search_path` if your vocabulary tables are not in the default schema.
+- `OMOP_EMB_API_KEY`: optional API key if your embedding service requires it.
 - `OMOP_EMB_EMBEDDING_PATH`: embedding endpoint path if `--embedding-path` is omitted.
 - `OMOP_EMB_MODEL`: default model name if `--model` is omitted.
 - `OMOP_EMB_EMBEDDING_DIM`: explicit embedding dimension override if `--embedding-dim` is omitted.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -21,6 +21,10 @@ At present, the production CLI path is PostgreSQL-oriented and stores embeddings
 
 - **Database**: Postgres implementation of OMOP CDM. See [`omop-graph` documentation](reference-missing) for information how to setup.
 - **Environment**: `OMOP_DATABASE_URL` must be exported or existing in the .env file  (e.g., `postgresql://user:pass@localhost:5432/omop`).
+- **Schema resolution**: OMOP vocabulary tables are resolved through the
+  PostgreSQL connection `search_path`. If your OMOP tables live in a schema such
+  as `staging_vocabulary`, ensure the connection resolves `concept` to that
+  schema.
 - **Connectivity**: Access to an embeddings endpoint compatible with the
   configured `omop-llm` client.
 
@@ -61,6 +65,8 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 ### Environment Variables
 
 - `OMOP_DATABASE_URL`: database connection string for the OMOP store.
+  The connection should resolve the OMOP `concept` table via PostgreSQL
+  `search_path` if your vocabulary tables are not in the default schema.
 - `OMOP_EMB_MODEL`: default model name if `--model` is omitted.
 - `OMOP_EMB_EMBEDDING_DIM`: explicit embedding dimension override if `--embedding-dim` is omitted.
 - `OMOP_EMB_BACKEND`: default embedding backend if `--backend` is omitted.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -20,6 +20,9 @@ At present, the production CLI path is PostgreSQL-oriented and stores embeddings
   ```
 
 - **Database**: Postgres implementation of OMOP CDM. See [`omop-graph` documentation](reference-missing) for information how to setup.
+- **Existing schema**: the CLI expects an existing OMOP database. It only
+  creates its own embedding registry/storage metadata and does not need to
+  bootstrap the full OMOP schema.
 - **Environment**: `OMOP_DATABASE_URL` must be exported or existing in the .env file  (e.g., `postgresql://user:pass@localhost:5432/omop`).
 - **Schema resolution**: OMOP vocabulary tables are resolved through the
   PostgreSQL connection `search_path`. If your OMOP tables live in a schema such

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -77,3 +77,25 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 - `OMOP_EMB_MODEL`: default model name if `--model` is omitted.
 - `OMOP_EMB_EMBEDDING_DIM`: explicit embedding dimension override if `--embedding-dim` is omitted.
 - `OMOP_EMB_BACKEND`: default embedding backend if `--backend` is omitted.
+
+## `search`
+
+### Usage
+```bash
+omop-emb search "type 2 diabetes" --api-base <URL> [OPTIONS]
+```
+
+This command embeds the query text and searches the stored embeddings for the
+selected model and backend.
+
+### Common options
+
+- `--model`: registered embedding model name to query.
+- `--backend`: `faiss` or `pgvector`.
+- `--metric-type`: nearest-neighbor metric, default `cosine`.
+- `--k`: number of results to return.
+- `--vocabulary`: optional vocabulary filter on the candidate concepts.
+- `--standard-only`: restrict search to standard OMOP concepts.
+
+The output is tab-separated with `rank`, `concept_id`, `similarity`, and
+`concept_name`.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -60,6 +60,7 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 | **`--batch-size`** | `-b` | `Integer` | `100` | Number of concepts to process in each chunk. |
 | **`--model`** | `-m` | `String` | `OMOP_EMB_MODEL` or `text-embedding-3-small` | Name of the embedding model to use for generating vectors. |
 | **`--embedding-dim`** | | `Integer` | `OMOP_EMB_EMBEDDING_DIM` or auto-detect | Explicit embedding dimension override for models whose dimensions cannot be inferred automatically. |
+| **`--overwrite-model-registration`** | | `Boolean` | `False` | Delete any existing registration and backend storage for this model name before re-registering it. |
 | **`--backend`** | | `Literal['pgvector', 'faiss']` | `None` | Embedding backend to use (can be replaced by `OMOP_EMB_BACKEND` env var). Requires the respective backend installed using `pip install omop-emb[pgvector or faiss]` |
 | **`--faiss-base-dir`** | | `String` | `None` | Optional base directory for FAISS backend storage. |
 | **`--standard-only`** | | `Boolean` | `False` | If set, only generate embeddings for OMOP standard concepts (`standard_concept = 'S'`). |

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -6,7 +6,9 @@ At present, the production CLI path is PostgreSQL-oriented and stores embeddings
 
 !!! note "Supported Models"
 
-    Currently supported are only Ollama models
+    The CLI works with the underlying `omop-llm` client. If your endpoint is
+    OpenAI-compatible and the client cannot infer embedding dimensions, pass
+    `--embedding-dim` or set `OMOP_EMB_EMBEDDING_DIM`.
 ---
 
 ## Prerequisites
@@ -19,7 +21,8 @@ At present, the production CLI path is PostgreSQL-oriented and stores embeddings
 
 - **Database**: Postgres implementation of OMOP CDM. See [`omop-graph` documentation](reference-missing) for information how to setup.
 - **Environment**: `OMOP_DATABASE_URL` must be exported or existing in the .env file  (e.g., `postgresql://user:pass@localhost:5432/omop`).
-- **Connectivity**: Access to an OpenAI-compatible embeddings endpoint. *Currently only Ollama supported*.
+- **Connectivity**: Access to an embeddings endpoint compatible with the
+  configured `omop-llm` client.
 
 !!! note "Backend Scope"
 
@@ -47,9 +50,17 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 | **`--api-key`** | | `String` | **Required** | API key for the embedding API provider. |
 | **`--index-type`** | | `IndexType` | `FLAT` | The storage index for the embeddings for retrieval. Currently supported: `FLAT`. |
 | **`--batch-size`** | `-b` | `Integer` | `100` | Number of concepts to process in each chunk. |
-| **`--model`** | `-m` | `String` | `text-embedding-3-small` | Name of the embedding model to use for generating vectors. |
+| **`--model`** | `-m` | `String` | `OMOP_EMB_MODEL` or `text-embedding-3-small` | Name of the embedding model to use for generating vectors. |
+| **`--embedding-dim`** | | `Integer` | `OMOP_EMB_EMBEDDING_DIM` or auto-detect | Explicit embedding dimension override for models whose dimensions cannot be inferred automatically. |
 | **`--backend`** | | `Literal['pgvector', 'faiss']` | `None` | Embedding backend to use (can be replaced by `OMOP_EMB_BACKEND` env var). Requires the respective backend installed using `pip install omop-emb[pgvector or faiss]` |
 | **`--faiss-base-dir`** | | `String` | `None` | Optional base directory for FAISS backend storage. |
 | **`--standard-only`** | | `Boolean` | `False` | If set, only generate embeddings for OMOP standard concepts (`standard_concept = 'S'`). |
 | **`--vocabulary`** | | `List[String]` | `None` | Filter to embed concepts only from specific OMOP vocabularies. |
 | **`--num-embeddings`** | `-n` | `Integer` | `None` | Limit the number of concepts processed (useful for testing). |
+
+### Environment Variables
+
+- `OMOP_DATABASE_URL`: database connection string for the OMOP store.
+- `OMOP_EMB_MODEL`: default model name if `--model` is omitted.
+- `OMOP_EMB_EMBEDDING_DIM`: explicit embedding dimension override if `--embedding-dim` is omitted.
+- `OMOP_EMB_BACKEND`: default embedding backend if `--backend` is omitted.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -2,7 +2,9 @@
 
 This tool generates vector embeddings for OMOP CDM concepts and stores them in the configured embedding backend.
 
-At present, the production CLI path is PostgreSQL-oriented and stores embeddings in Postgres/pgvector-backed model tables. It specifically targets concepts that do not yet have embeddings and processes them in batches.
+The CLI targets concepts that do not yet have embeddings for the selected model
+and backend, processes them in batches, and stores the results in either the
+`pgvector` or `faiss` backend.
 
 !!! note "Supported Models"
 
@@ -16,7 +18,8 @@ At present, the production CLI path is PostgreSQL-oriented and stores embeddings
 - **Installation**: install the PostgreSQL backend dependencies:
 
   ```bash
-  pip install "omop-emb[postgres]"
+  pip install "omop-emb[pgvector]"
+  pip install "omop-emb[faiss]"
   ```
 
 - **Database**: Postgres implementation of OMOP CDM. See [`omop-graph` documentation](reference-missing) for information how to setup.
@@ -28,13 +31,9 @@ At present, the production CLI path is PostgreSQL-oriented and stores embeddings
   PostgreSQL connection `search_path`. If your OMOP tables live in a schema such
   as `staging_vocabulary`, ensure the connection resolves `concept` to that
   schema.
-- **Connectivity**: Access to an embeddings endpoint compatible with the
-  configured `omop-llm` client.
-
-!!! note "Backend Scope"
-
-    `omop-emb` now defines a backend abstraction layer for both PostgreSQL and FAISS-style storage.
-    The current `add-embeddings` CLI still targets the PostgreSQL backend path.
+- **Connectivity**: Access to an embedding endpoint that accepts batched text
+  input and returns numeric embedding vectors. OpenAI-compatible APIs and
+  custom shim services are supported via `--api-base` plus `--embedding-path`.
 
 ---
 
@@ -42,7 +41,7 @@ At present, the production CLI path is PostgreSQL-oriented and stores embeddings
 
 ### Usage
 ```bash
-omop-emb add-embeddings --api-base <URL> --api-key <KEY> [OPTIONS]
+omop-emb add-embeddings --api-base <URL> [OPTIONS]
 ```
 where `[OPTIONS]` are optional arguments that can be specified as described below.
 
@@ -60,8 +59,8 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 | **`--batch-size`** | `-b` | `Integer` | `100` | Number of concepts to process in each chunk. |
 | **`--model`** | `-m` | `String` | `OMOP_EMB_MODEL` or `text-embedding-3-small` | Name of the embedding model to use for generating vectors. |
 | **`--embedding-dim`** | | `Integer` | `OMOP_EMB_EMBEDDING_DIM` or auto-detect | Explicit embedding dimension override for models whose dimensions cannot be inferred automatically. |
-| **`--overwrite-model-registration`** | | `Boolean` | `False` | Delete any existing registration and backend storage for this model name before re-registering it. |
-| **`--backend`** | | `Literal['pgvector', 'faiss']` | `None` | Embedding backend to use (can be replaced by `OMOP_EMB_BACKEND` env var). Requires the respective backend installed using `pip install omop-emb[pgvector or faiss]` |
+| **`--overwrite-model-registration`** | | `Boolean` | `False` | Force a clean rebuild for this model name by deleting backend-owned storage and SQL registration before re-registering it. |
+| **`--backend`** | | `Literal['pgvector', 'faiss']` | `OMOP_EMB_BACKEND` | Embedding backend to use. Requires the respective backend extra to be installed. |
 | **`--faiss-base-dir`** | | `String` | `None` | Optional base directory for FAISS backend storage. |
 | **`--standard-only`** | | `Boolean` | `False` | If set, only generate embeddings for OMOP standard concepts (`standard_concept = 'S'`). |
 | **`--vocabulary`** | | `List[String]` | `None` | Filter to embed concepts only from specific OMOP vocabularies. |
@@ -72,11 +71,35 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 - `OMOP_DATABASE_URL`: database connection string for the OMOP store.
   The connection should resolve the OMOP `concept` table via PostgreSQL
   `search_path` if your vocabulary tables are not in the default schema.
+- `OMOP_EMB_METADATA_SCHEMA`: schema for `omop-emb`'s own `model_registry` and
+  backend-specific metadata tables. Defaults to `public`.
 - `OMOP_EMB_API_KEY`: optional API key if your embedding service requires it.
 - `OMOP_EMB_EMBEDDING_PATH`: embedding endpoint path if `--embedding-path` is omitted.
 - `OMOP_EMB_MODEL`: default model name if `--model` is omitted.
 - `OMOP_EMB_EMBEDDING_DIM`: explicit embedding dimension override if `--embedding-dim` is omitted.
 - `OMOP_EMB_BACKEND`: default embedding backend if `--backend` is omitted.
+- `OMOP_EMB_FAISS_INDEX_DIR`: optional FAISS storage base dir used when the backend is `faiss`.
+
+### Notes
+
+- `--api-base` should be the base service URL such as `http://localhost:8000/v1`,
+  not the full embeddings endpoint. Use `--embedding-path` for endpoint shapes
+  such as `/embeddings` or `/embed`.
+- `--api-key` is optional. If omitted, no bearer token is sent.
+- `--num-embeddings` is only an upper bound. The actual selected count may be
+  lower, including zero.
+- `OMOP_EMB_METADATA_SCHEMA` is separate from the OMOP vocabulary schema. It
+  controls where `omop-emb` stores `model_registry` and backend-owned tables,
+  while `concept` is still resolved through the database connection's
+  `search_path`.
+- If an existing model name is already registered with different dimensions or
+  other incompatible configuration, use `--overwrite-model-registration` to
+  delete the old backend storage and re-register it.
+- For FAISS, `--overwrite-model-registration` also deletes the model's on-disk
+  directory so stale HDF5/index files cannot survive into the rebuild.
+- If stale FAISS artifacts exist on disk without a matching SQL registration,
+  the CLI now fails early and tells you to rerun with
+  `--overwrite-model-registration`.
 
 ## `search`
 
@@ -96,6 +119,8 @@ selected model and backend.
 - `--k`: number of results to return.
 - `--vocabulary`: optional vocabulary filter on the candidate concepts.
 - `--standard-only`: restrict search to standard OMOP concepts.
+- `--embedding-path`: relative embedding endpoint path such as `/embeddings` or `/embed`.
+- `--api-key`: optional bearer token for the embedding service.
 
 The output is tab-separated with `rank`, `concept_id`, `similarity`, and
 `concept_name`.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -53,7 +53,8 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 
 | Option | Short | Type | Default | Description |
 | :--- | :--- | :--- | :--- | :--- |
-| **`--api-base`** | | `String` | **Required** | Base URL for the embedding API service. |
+| **`--api-base`** | | `String` | **Required** | Base URL for the embedding API service, e.g. `http://localhost:8000/v1`. |
+| **`--embedding-path`** | | `String` | `/embeddings` or `OMOP_EMB_EMBEDDING_PATH` | Relative path for the embedding endpoint, e.g. `/embeddings` or `/embed`. |
 | **`--api-key`** | | `String` | **Required** | API key for the embedding API provider. |
 | **`--index-type`** | | `IndexType` | `FLAT` | The storage index for the embeddings for retrieval. Currently supported: `FLAT`. |
 | **`--batch-size`** | `-b` | `Integer` | `100` | Number of concepts to process in each chunk. |
@@ -70,6 +71,7 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 - `OMOP_DATABASE_URL`: database connection string for the OMOP store.
   The connection should resolve the OMOP `concept` table via PostgreSQL
   `search_path` if your vocabulary tables are not in the default schema.
+- `OMOP_EMB_EMBEDDING_PATH`: embedding endpoint path if `--embedding-path` is omitted.
 - `OMOP_EMB_MODEL`: default model name if `--model` is omitted.
 - `OMOP_EMB_EMBEDDING_DIM`: explicit embedding dimension override if `--embedding-dim` is omitted.
 - `OMOP_EMB_BACKEND`: default embedding backend if `--backend` is omitted.

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -62,6 +62,9 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
 | **`--overwrite-model-registration`** | | `Boolean` | `False` | Force a clean rebuild for this model name by deleting backend-owned storage and SQL registration before re-registering it. |
 | **`--backend`** | | `Literal['pgvector', 'faiss']` | `OMOP_EMB_BACKEND` | Embedding backend to use. Requires the respective backend extra to be installed. |
 | **`--faiss-base-dir`** | | `String` | `None` | Optional base directory for FAISS backend storage. |
+| **`--hnsw-num-neighbors`** | | `Integer` | `32` | FAISS HNSW `M` parameter when `--index-type hnsw`. |
+| **`--hnsw-ef-search`** | | `Integer` | `64` | FAISS HNSW `efSearch` parameter when `--index-type hnsw`. |
+| **`--hnsw-ef-construction`** | | `Integer` | `200` | FAISS HNSW `efConstruction` parameter when `--index-type hnsw`. |
 | **`--standard-only`** | | `Boolean` | `False` | If set, only generate embeddings for OMOP standard concepts (`standard_concept = 'S'`). |
 | **`--vocabulary`** | | `List[String]` | `None` | Filter to embed concepts only from specific OMOP vocabularies. |
 | **`--num-embeddings`** | `-n` | `Integer` | `None` | Limit the number of concepts processed (useful for testing). |
@@ -101,6 +104,32 @@ where `[OPTIONS]` are optional arguments that can be specified as described belo
   the CLI now fails early and tells you to rerun with
   `--overwrite-model-registration`.
 - For larger FAISS stores, prefer `--index-type hnsw` over `flat`.
+
+### FAISS Storage Layout
+
+When `--backend faiss` is used, `add-embeddings` writes the raw vectors and
+concept IDs into an HDF5 file first. That HDF5 file is the durable source of
+truth for the stored embeddings.
+
+FAISS search indexes are separate files derived from the HDF5 data and they are
+metric-specific. For example, a model directory may contain:
+
+- `embeddings.h5`: raw vectors and concept IDs
+- `index_flat/flat_cosine_index.faiss`: cosine search index
+- `index_flat/flat_l2_index.faiss`: L2 search index
+
+This means:
+
+- creating embeddings does not by itself guarantee that every FAISS metric
+  index already exists;
+- `search` defaults to `--metric-type cosine`;
+- if the required FAISS index file for the chosen metric is missing, it may be
+  built lazily from `embeddings.h5` on first search, which can take a long time
+  for large stores;
+- for large datasets, prefer running `rebuild-index` explicitly for the metric
+  or metrics you plan to query.
+- when `--index-type hnsw` is used, the chosen HNSW settings are stored in the
+  model registry metadata and reused for later rebuilds and searches.
 
 ## `search`
 
@@ -145,3 +174,49 @@ index files or when you want to materialize multiple metrics ahead of time.
 - `--metric-type`: repeat to rebuild multiple metrics. If omitted, all metrics
   supported by the model's index type are rebuilt.
 - `--batch-size`: streaming batch size used while rebuilding from HDF5.
+
+Examples:
+
+```bash
+omop-emb rebuild-index \
+  --model my-embedding-model \
+  --backend faiss \
+  --faiss-base-dir ./data \
+  --metric-type cosine
+```
+
+If you plan to search with multiple metrics, rebuild each required metric or
+omit `--metric-type` to build all metrics supported by the model's index type.
+
+## `switch-index-type`
+
+### Usage
+```bash
+omop-emb switch-index-type --model <MODEL> --backend faiss [OPTIONS]
+```
+
+This command updates the registered FAISS `index_type` for an existing model,
+stores any HNSW configuration in the model metadata, and optionally rebuilds
+the derived FAISS index files from `embeddings.h5`.
+
+Common options:
+
+- `--index-type`: target FAISS index type such as `hnsw` or `flat`.
+- `--metric-type`: metric(s) to rebuild after switching. If omitted, all
+  metrics supported by the target index type are rebuilt.
+- `--hnsw-num-neighbors`: HNSW `M` parameter for `--index-type hnsw`.
+- `--hnsw-ef-search`: HNSW `efSearch` parameter for `--index-type hnsw`.
+- `--hnsw-ef-construction`: HNSW `efConstruction` parameter for `--index-type hnsw`.
+- `--rebuild/--no-rebuild`: rebuild FAISS files immediately after switching.
+
+Example:
+
+```bash
+omop-emb switch-index-type \
+  --model my-embedding-model \
+  --backend faiss \
+  --index-type hnsw \
+  --hnsw-num-neighbors 48 \
+  --hnsw-ef-search 96 \
+  --hnsw-ef-construction 240
+```

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -220,6 +220,12 @@ omop-emb serve-search --api-base <URL> [OPTIONS]
 This command starts a small HTTP service that keeps the embedding client and
 FAISS index warm in one long-lived process.
 
+Current behavior:
+
+- the service is intentionally single-threaded;
+- requests are handled one at a time in arrival order;
+- overlapping requests wait in the server queue until the active request completes.
+
 Endpoints:
 
 - `GET /health`: basic health/status response
@@ -255,6 +261,20 @@ Common options:
 - `--host`, `--port`: bind address for the service
 - `--warm-index/--no-warm-index`: preload the FAISS index before accepting requests
 - `--metric-type`, `--k`, `--vocabulary`, `--standard-only`: default search configuration used by requests
+
+Example startup command:
+
+```bash
+omop-emb serve-search \
+  --api-base http://localhost:14000/v1 \
+  --embedding-path /embeddings \
+  --model tei-qwen:intfloat/multilingual-e5-large-instruct \
+  --backend faiss \
+  --faiss-base-dir /media/large-backup-drive/omop-embeddings \
+  --metric-type cosine \
+  --host 127.0.0.1 \
+  --port 18080
+```
 
 ## `rebuild-index`
 

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -155,6 +155,107 @@ selected model and backend.
 The output is tab-separated with `rank`, `concept_id`, `similarity`, and
 `concept_name`.
 
+### Timing visibility
+
+The search path now emits timing logs for the main phases of a request:
+
+- query embedding HTTP call
+- FAISS index load from disk, if it was not already loaded in-process
+- FAISS nearest-neighbor search
+- SQL metadata hydration for returned concept IDs
+
+This is useful for distinguishing one-time index warmup cost from steady-state
+query latency.
+
+## `search-batch`
+
+### Usage
+```bash
+omop-emb search-batch queries.txt --api-base <URL> [OPTIONS]
+```
+
+This command runs many searches in one Python process so FAISS index loading
+and client initialization happen once instead of once per shell invocation.
+
+Input file format:
+
+- one query per line, or
+- `query_id<TAB>query_text` per line
+
+Output is tab-separated:
+
+- `query_id`
+- `query_text`
+- `rank`
+- `concept_id`
+- `similarity`
+- `concept_name`
+
+Common options:
+
+- `--batch-size`: number of query texts to embed and search together
+- `--warm-index/--no-warm-index`: preload the FAISS index before processing
+- `--metric-type`, `--k`, `--vocabulary`, `--standard-only`: same semantics as `search`
+
+Example:
+
+```bash
+omop-emb search-batch queries.tsv \
+  --api-base http://localhost:14000/v1 \
+  --embedding-path /embeddings \
+  --model tei-qwen:intfloat/multilingual-e5-large-instruct \
+  --backend faiss \
+  --faiss-base-dir /media/large-backup-drive/omop-embeddings \
+  --metric-type cosine \
+  --k 5
+```
+
+## `serve-search`
+
+### Usage
+```bash
+omop-emb serve-search --api-base <URL> [OPTIONS]
+```
+
+This command starts a small HTTP service that keeps the embedding client and
+FAISS index warm in one long-lived process.
+
+Endpoints:
+
+- `GET /health`: basic health/status response
+- `POST /search`: JSON request body with `query_text`, optional `query_id`, and optional `k`
+
+Example request:
+
+```bash
+curl -X POST http://127.0.0.1:8080/search \
+  -H 'Content-Type: application/json' \
+  -d '{"query_id":"1","query_text":"Xanthomonapepsin","k":5}'
+```
+
+Example response:
+
+```json
+{
+  "query_id": "1",
+  "query_text": "Xanthomonapepsin",
+  "matches": [
+    {
+      "rank": 1,
+      "concept_id": 4238563,
+      "similarity": 0.940029,
+      "concept_name": "Phomopsin"
+    }
+  ]
+}
+```
+
+Common options:
+
+- `--host`, `--port`: bind address for the service
+- `--warm-index/--no-warm-index`: preload the FAISS index before accepting requests
+- `--metric-type`, `--k`, `--vocabulary`, `--standard-only`: default search configuration used by requests
+
 ## `rebuild-index`
 
 ### Usage

--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -18,7 +18,7 @@ requires database-backed OMOP access and model registration.
 ## PostgreSQL backend
 
 ```bash
-pip install "omop-emb[postgres]"
+pip install "omop-emb[pgvector]"
 ```
 
 Use this when you want the current pgvector/PostgreSQL-backed embedding store
@@ -52,7 +52,7 @@ install-time.
 Examples:
 
 ```bash
-export OMOP_EMB_BACKEND=postgres
+export OMOP_EMB_BACKEND=pgvector
 export OMOP_EMB_BACKEND=faiss
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 markers = [
   "unit: Unit tests",
+  "integration: Integration tests that require external services such as PostgreSQL",
   "faiss: FAISS backend tests",
   "pgvector: pgvector backend tests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "numpy>=1.26",
     "omop-alchemy>=0.5.7",
     "orm-loader>=0.3.15",
+    "requests>=2.31",
     "sqlalchemy>=2.0.45",
     "typing-extensions>=4.15.0",
     "psycopg2-binary>=2.9.11",

--- a/src/omop_emb/backends/base.py
+++ b/src/omop_emb/backends/base.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session, mapped_column
 
 from omop_alchemy.cdm.model.vocabulary import Concept
 
-from .registry import ModelRegistry, ensure_model_registry_schema
+from .registry import ModelRegistry, ensure_model_registry_schema, get_metadata_schema
 from .config import BackendType, SUPPORTED_INDICES_AND_METRICS_PER_BACKEND, IndexType, MetricType
 from .errors import ModelRegistrationConflictError
 from .embedding_utils import (
@@ -115,6 +115,15 @@ class EmbeddingBackend(ABC, Generic[T]):
                 # Create the class and cache it
                 dynamic_table = self._create_storage_table(engine=engine, entry=model_entry)
                 self.model_cache[model_entry.model_name] = dynamic_table
+
+    def has_stale_model_artifacts(self, model_name: str) -> bool:
+        """
+        Return True if backend-owned artifacts exist for ``model_name`` outside
+        the SQL registry.
+
+        Backends without external storage can use the default implementation.
+        """
+        return False
 
     def list_registered_models(self, session: Session) -> Sequence[EmbeddingModelRecord]:
         """Return all embedding models known to this backend."""
@@ -390,7 +399,9 @@ class EmbeddingBackend(ABC, Generic[T]):
             return False
 
         session.execute(
-            text(f'DROP TABLE IF EXISTS "{record.storage_identifier}" CASCADE')
+            text(
+                f'DROP TABLE IF EXISTS "{get_metadata_schema()}"."{record.storage_identifier}" CASCADE'
+            )
         )
         row = session.scalar(
             select(ModelRegistry).where(

--- a/src/omop_emb/backends/base.py
+++ b/src/omop_emb/backends/base.py
@@ -102,6 +102,7 @@ class EmbeddingBackend(ABC, Generic[T]):
         - warm caches from a registry
         - create directories or sidecar files
         """
+        ensure_model_registry_schema(engine)
 
         with Session(engine, expire_on_commit=False) as session:
             existing_models = session.scalars(select(ModelRegistry).where(ModelRegistry.backend_type == self.backend_type)).all()

--- a/src/omop_emb/backends/base.py
+++ b/src/omop_emb/backends/base.py
@@ -377,6 +377,32 @@ class EmbeddingBackend(ABC, Generic[T]):
         backends may choose to rebuild or compact a search index here.
         """
         return None
+
+    def delete_model(
+        self,
+        *,
+        engine: Engine,
+        session: Session,
+        model_name: str,
+    ) -> bool:
+        record = self.get_registered_model(session=session, model_name=model_name)
+        if record is None:
+            return False
+
+        session.execute(
+            text(f'DROP TABLE IF EXISTS "{record.storage_identifier}" CASCADE')
+        )
+        row = session.scalar(
+            select(ModelRegistry).where(
+                ModelRegistry.model_name == model_name,
+                ModelRegistry.backend_type == self.backend_type,
+            )
+        )
+        if row is not None:
+            session.delete(row)
+        session.commit()
+        self.model_cache.pop(model_name, None)
+        return True
     
     def has_any_embeddings(self, session: Session, model_name: str) -> bool:
         embedding_table = self._get_embedding_table(

--- a/src/omop_emb/backends/config.py
+++ b/src/omop_emb/backends/config.py
@@ -47,7 +47,8 @@ SUPPORTED_INDICES_AND_METRICS_PER_BACKEND: Dict[BackendType, Dict[IndexType, Tup
     },
     # Check here: https://github.com/facebookresearch/faiss/wiki/Faiss-indexes
     BackendType.FAISS: {
-        IndexType.FLAT: (MetricType.L2, MetricType.COSINE)
+        IndexType.FLAT: (MetricType.L2, MetricType.COSINE),
+        IndexType.HNSW: (MetricType.L2, MetricType.COSINE),
     }
 }
 
@@ -63,3 +64,7 @@ def is_index_type_supported_for_backend(backend: BackendType, index: IndexType) 
 def get_supported_index_types_for_backend(backend: BackendType) -> Tuple[IndexType, ...]:
     supported_indices_and_metrics = SUPPORTED_INDICES_AND_METRICS_PER_BACKEND.get(backend, {})
     return tuple(supported_indices_and_metrics.keys())
+
+def get_supported_metrics_for_backend_index(backend: BackendType, index: IndexType) -> Tuple[MetricType, ...]:
+    supported_indices_and_metrics = SUPPORTED_INDICES_AND_METRICS_PER_BACKEND.get(backend, {})
+    return supported_indices_and_metrics.get(index, ())

--- a/src/omop_emb/backends/faiss/faiss_backend.py
+++ b/src/omop_emb/backends/faiss/faiss_backend.py
@@ -128,6 +128,12 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
     
     def get_safe_model_dir(self, model_name: str) -> Path:
         return self.base_dir / self.safe_model_name(model_name)
+
+    def has_stale_model_artifacts(self, model_name: str) -> bool:
+        model_dir = self.get_safe_model_dir(model_name)
+        if not model_dir.exists():
+            return False
+        return any(model_dir.iterdir())
     
     def get_storage_manager(
         self, 
@@ -199,6 +205,7 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
         self.embedding_storage_managers.pop(model_name, None)
         model_dir = self.get_safe_model_dir(model_name)
         if model_dir.exists():
+            logger.info("Deleting FAISS model directory for '%s': %s", model_name, model_dir)
             shutil.rmtree(model_dir)
         return deleted
 

--- a/src/omop_emb/backends/faiss/faiss_backend.py
+++ b/src/omop_emb/backends/faiss/faiss_backend.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 import shutil
+import time
 from typing import Any, Mapping, Optional, Sequence, Type, cast, Dict, Tuple 
 
 import numpy as np
@@ -486,6 +487,7 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
             # Easier to not do any filter if all are allowed
             permitted_concept_ids = None
         else:
+            filter_started_at = time.monotonic()
             q_permitted_concept_ids = (
                 select(embedding_table.concept_id)
                 .join(Concept, Concept.concept_id == embedding_table.concept_id)
@@ -495,13 +497,26 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
                 [int(row.concept_id) for row in session.execute(q_permitted_concept_ids)],
                 dtype=np.int64,
             )
+            logger.info(
+                "Resolved FAISS filter candidate set: model=%s count=%s elapsed=%.3fs",
+                model_name,
+                len(permitted_concept_ids),
+                time.monotonic() - filter_started_at,
+            )
 
+        faiss_search_started_at = time.monotonic()
         distances, concept_ids = storage_manager.search(
             query_vector=query_embeddings,
             metric_type=metric_type,
             index_type=model_record.index_type,
             k=k,
             subset_concept_ids=permitted_concept_ids
+        )
+        logger.info(
+            "Completed backend nearest-neighbor stage: model=%s queries=%s elapsed=%.3fs",
+            model_name,
+            query_embeddings.shape[0],
+            time.monotonic() - faiss_search_started_at,
         )
 
         returned_ids = tuple(
@@ -512,6 +527,7 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
         if not returned_ids:
             return tuple(() for _ in range(query_embeddings.shape[0]))
 
+        hydration_started_at = time.monotonic()
         permitted_concept_ids_storage = {
             row.concept_id: row
             for row in session.execute(
@@ -522,6 +538,12 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
                 )
             )
         }
+        logger.info(
+            "Hydrated FAISS result metadata: model=%s concepts=%s elapsed=%.3fs",
+            model_name,
+            len(permitted_concept_ids_storage),
+            time.monotonic() - hydration_started_at,
+        )
 
         matches = []
         for concept_id_pery_query, distance_per_query in zip(concept_ids, distances):

--- a/src/omop_emb/backends/faiss/faiss_backend.py
+++ b/src/omop_emb/backends/faiss/faiss_backend.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping, Optional, Sequence, Type, cast, Dict, Tuple
 import numpy as np
 from numpy import ndarray
 from omop_emb.backends.config import BackendType
-from sqlalchemy import Engine, insert, select
+from sqlalchemy import Engine, insert, select, func
 from sqlalchemy.orm import Session
 import logging
 from dataclasses import dataclass, field
@@ -24,7 +24,12 @@ from .faiss_sql import (
     add_concept_ids_to_faiss_registry,
     q_concept_ids_with_embeddings
 )
-from ..config import IndexType, MetricType, ENV_OMOP_EMB_FAISS_INDEX_DIR
+from ..config import (
+    IndexType,
+    MetricType,
+    ENV_OMOP_EMB_FAISS_INDEX_DIR,
+    get_supported_metrics_for_backend_index,
+)
 from .storage_manager import EmbeddingStorageManager
 from ..base import EmbeddingBackend, require_registered_model
 from ..embedding_utils import (
@@ -164,6 +169,23 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
                     backend_type=self.backend_type,
                 )
 
+    def _validate_storage_consistency(
+        self,
+        *,
+        session: Session,
+        model_name: str,
+        storage_manager: EmbeddingStorageManager,
+    ) -> None:
+        embedding_table = self._get_embedding_table(session, model_name)
+        registry_count = session.scalar(select(func.count()).select_from(embedding_table))
+        storage_count = storage_manager.get_count()
+        if registry_count != storage_count:
+            raise RuntimeError(
+                f"FAISS storage is inconsistent for model '{model_name}': SQL registry has "
+                f"{registry_count} concept_ids but HDF5 storage has {storage_count} vectors. "
+                "Re-run with `--overwrite-model-registration` or rebuild after cleanup."
+            )
+
     def register_model(
         self,
         engine: Engine,
@@ -261,6 +283,16 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
         """
 
         concept_id_tuple = tuple(concept_ids)
+        storage_manager = self.get_storage_manager(
+            model_name=model_name,
+            dimensions=model_record.dimensions,
+            index_type=model_record.index_type,
+        )
+        self._validate_storage_consistency(
+            session=session,
+            model_name=model_name,
+            storage_manager=storage_manager,
+        )
         self.validate_embeddings_and_concept_ids(
             concept_ids=concept_id_tuple,
             embeddings=embeddings,
@@ -280,11 +312,6 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
                 f"Failed to add concept IDs to FAISS registry for model '{model_name}'. This may be due to a mismatch between the provided concept_ids and the existing entries in the database, or a database constraint violation. Original error: {str(e)}"
             ) from e
         
-        storage_manager = self.get_storage_manager(
-            model_name=model_name,
-            dimensions=model_record.dimensions,
-            index_type=model_record.index_type,
-        )
         storage_manager.append(
             concept_ids=np.array(concept_id_tuple, dtype=np.int64),
             embeddings=embeddings,
@@ -314,22 +341,27 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
         if storage_manager.get_count() == 0:
             return ()
 
-        self.validate_embeddings(embeddings=query_embeddings, dimensions=model_record.dimensions)
-        q_permitted_concept_ids = q_concept_ids_with_embeddings(
-            embedding_table=self._get_embedding_table(session, model_name),
-            concept_filter=concept_filter,
-            limit=None
+        self._validate_storage_consistency(
+            session=session,
+            model_name=model_name,
+            storage_manager=storage_manager,
         )
-
-        permitted_concept_ids_storage = {
-            row.concept_id: row for row in session.execute(q_permitted_concept_ids)
-        }
+        self.validate_embeddings(embeddings=query_embeddings, dimensions=model_record.dimensions)
+        embedding_table = self._get_embedding_table(session, model_name)
 
         if concept_filter is None:
             # Easier to not do any filter if all are allowed
             permitted_concept_ids = None
         else:
-            permitted_concept_ids = np.array(list(permitted_concept_ids_storage.keys()), dtype=np.int64)
+            q_permitted_concept_ids = (
+                select(embedding_table.concept_id)
+                .join(Concept, Concept.concept_id == embedding_table.concept_id)
+            )
+            q_permitted_concept_ids = concept_filter.apply(q_permitted_concept_ids)
+            permitted_concept_ids = np.array(
+                [int(row.concept_id) for row in session.execute(q_permitted_concept_ids)],
+                dtype=np.int64,
+            )
 
         distances, concept_ids = storage_manager.search(
             query_vector=query_embeddings,
@@ -338,6 +370,25 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
             k=k,
             subset_concept_ids=permitted_concept_ids
         )
+
+        returned_ids = tuple(
+            int(concept_id)
+            for concept_id in np.unique(concept_ids)
+            if int(concept_id) != -1
+        )
+        if not returned_ids:
+            return tuple(() for _ in range(query_embeddings.shape[0]))
+
+        permitted_concept_ids_storage = {
+            row.concept_id: row
+            for row in session.execute(
+                q_concept_ids_with_embeddings(
+                    embedding_table=embedding_table,
+                    concept_filter=EmbeddingConceptFilter(concept_ids=returned_ids),
+                    limit=None,
+                )
+            )
+        }
 
         matches = []
         for concept_id_pery_query, distance_per_query in zip(concept_ids, distances):
@@ -361,7 +412,48 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
 
     @require_registered_model
     def refresh_model_index(self, session: Session, model_name: str, model_record: EmbeddingModelRecord) -> None:
-        raise NotImplementedError("Explicit index refresh is not required for the FAISS backend as it updates the index on each upsert. This method is a no-op.")
+        self.rebuild_model_indexes(
+            session=session,
+            model_name=model_name,
+            model_record=model_record,
+            metric_types=None,
+        )
+
+    @require_registered_model
+    def rebuild_model_indexes(
+        self,
+        session: Session,
+        model_name: str,
+        model_record: EmbeddingModelRecord,
+        metric_types: Optional[Sequence[MetricType]] = None,
+        batch_size: int = 100_000,
+    ) -> None:
+        storage_manager = self.get_storage_manager(
+            model_name=model_name,
+            dimensions=model_record.dimensions,
+            index_type=model_record.index_type,
+        )
+        self._validate_storage_consistency(
+            session=session,
+            model_name=model_name,
+            storage_manager=storage_manager,
+        )
+        metrics = tuple(metric_types) if metric_types is not None else get_supported_metrics_for_backend_index(
+            self.backend_type,
+            model_record.index_type,
+        )
+        for metric_type in metrics:
+            logger.info(
+                "Rebuilding FAISS index for model '%s' with index_type=%s metric=%s",
+                model_name,
+                model_record.index_type,
+                metric_type,
+            )
+            storage_manager.rebuild_index(
+                index_type=model_record.index_type,
+                metric_type=metric_type,
+                batch_size=batch_size,
+            )
     
     @require_registered_model
     def get_embeddings_by_concept_ids(

--- a/src/omop_emb/backends/faiss/faiss_backend.py
+++ b/src/omop_emb/backends/faiss/faiss_backend.py
@@ -42,6 +42,84 @@ from ..embedding_utils import (
 
 logger = logging.getLogger(__name__)
 
+FAISS_METADATA_HNSW_NUM_NEIGHBORS = "hnsw_num_neighbors"
+FAISS_METADATA_HNSW_EF_SEARCH = "hnsw_ef_search"
+FAISS_METADATA_HNSW_EF_CONSTRUCTION = "hnsw_ef_construction"
+DEFAULT_HNSW_NUM_NEIGHBORS = 32
+DEFAULT_HNSW_EF_SEARCH = 64
+DEFAULT_HNSW_EF_CONSTRUCTION = 200
+
+
+def _coerce_positive_int(*, value: Optional[object], field_name: str, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        resolved = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an integer. Got {value!r}.") from exc
+    if resolved <= 0:
+        raise ValueError(f"{field_name} must be a positive integer. Got {resolved}.")
+    return resolved
+
+
+def build_faiss_index_metadata(
+    *,
+    index_type: IndexType,
+    existing_metadata: Optional[Mapping[str, object]] = None,
+    hnsw_num_neighbors: Optional[int] = None,
+    hnsw_ef_search: Optional[int] = None,
+    hnsw_ef_construction: Optional[int] = None,
+) -> dict[str, object]:
+    metadata = dict(existing_metadata or {})
+    for key in (
+        FAISS_METADATA_HNSW_NUM_NEIGHBORS,
+        FAISS_METADATA_HNSW_EF_SEARCH,
+        FAISS_METADATA_HNSW_EF_CONSTRUCTION,
+    ):
+        metadata.pop(key, None)
+
+    if index_type == IndexType.HNSW:
+        metadata[FAISS_METADATA_HNSW_NUM_NEIGHBORS] = _coerce_positive_int(
+            value=hnsw_num_neighbors,
+            field_name=FAISS_METADATA_HNSW_NUM_NEIGHBORS,
+            default=DEFAULT_HNSW_NUM_NEIGHBORS,
+        )
+        metadata[FAISS_METADATA_HNSW_EF_SEARCH] = _coerce_positive_int(
+            value=hnsw_ef_search,
+            field_name=FAISS_METADATA_HNSW_EF_SEARCH,
+            default=DEFAULT_HNSW_EF_SEARCH,
+        )
+        metadata[FAISS_METADATA_HNSW_EF_CONSTRUCTION] = _coerce_positive_int(
+            value=hnsw_ef_construction,
+            field_name=FAISS_METADATA_HNSW_EF_CONSTRUCTION,
+            default=DEFAULT_HNSW_EF_CONSTRUCTION,
+        )
+
+    return metadata
+
+
+def resolve_faiss_hnsw_parameters(
+    metadata: Optional[Mapping[str, object]],
+) -> tuple[int, int, int]:
+    metadata = metadata or {}
+    return (
+        _coerce_positive_int(
+            value=metadata.get(FAISS_METADATA_HNSW_NUM_NEIGHBORS),
+            field_name=FAISS_METADATA_HNSW_NUM_NEIGHBORS,
+            default=DEFAULT_HNSW_NUM_NEIGHBORS,
+        ),
+        _coerce_positive_int(
+            value=metadata.get(FAISS_METADATA_HNSW_EF_SEARCH),
+            field_name=FAISS_METADATA_HNSW_EF_SEARCH,
+            default=DEFAULT_HNSW_EF_SEARCH,
+        ),
+        _coerce_positive_int(
+            value=metadata.get(FAISS_METADATA_HNSW_EF_CONSTRUCTION),
+            field_name=FAISS_METADATA_HNSW_EF_CONSTRUCTION,
+            default=DEFAULT_HNSW_EF_CONSTRUCTION,
+        ),
+    )
+
 @dataclass
 class FaissMetadata:
     """Strongly typed metadata required for the FAISS backend to operate."""
@@ -145,11 +223,13 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
         model_name: str,
         dimensions: int,
         index_type: IndexType,
+        metadata: Optional[Mapping[str, object]] = None,
     ) -> EmbeddingStorageManager:
         self.register_storage_manager(
             model_name=model_name,
             dimensions=dimensions,
             index_type=index_type,
+            metadata=metadata,
         )
         return self.embedding_storage_managers[model_name]
     
@@ -158,16 +238,67 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
         model_name: str,
         dimensions: int,
         index_type: IndexType,
+        metadata: Optional[Mapping[str, object]] = None,
     ) -> None:
         """Registers a storage manager for the given model if not already registered. This ensures that the necessary on-disk structures are in place for the model's embeddings and index."""
 
-        if model_name not in self.embedding_storage_managers:
+        hnsw_num_neighbors, hnsw_ef_search, hnsw_ef_construction = resolve_faiss_hnsw_parameters(metadata)
+        existing_manager = self.embedding_storage_managers.get(model_name)
+        if (
+            existing_manager is None
+            or existing_manager.dimensions != dimensions
+            or existing_manager.hnsw_num_neighbors != hnsw_num_neighbors
+            or existing_manager.hnsw_ef_search != hnsw_ef_search
+            or existing_manager.hnsw_ef_construction != hnsw_ef_construction
+        ):
             logger.info(f"Registering new storage manager for model '{model_name}' with dimensions={dimensions}, index_type={index_type}")
             self.embedding_storage_managers[model_name] = EmbeddingStorageManager(
-                    file_dir=self.get_safe_model_dir(model_name), 
-                    dimensions=dimensions,
-                    backend_type=self.backend_type,
+                file_dir=self.get_safe_model_dir(model_name), 
+                dimensions=dimensions,
+                backend_type=self.backend_type,
+                hnsw_num_neighbors=hnsw_num_neighbors,
+                hnsw_ef_search=hnsw_ef_search,
+                hnsw_ef_construction=hnsw_ef_construction,
+            )
+
+    def update_model_index_configuration(
+        self,
+        *,
+        session: Session,
+        model_name: str,
+        index_type: IndexType,
+        metadata: Mapping[str, object],
+    ) -> EmbeddingModelRecord:
+        row = session.scalar(
+            select(ModelRegistry).where(
+                ModelRegistry.model_name == model_name,
+                ModelRegistry.backend_type == self.backend_type,
+            )
+        )
+        if row is None:
+            raise ValueError(
+                f"Embedding model '{model_name}' is not registered in the FAISS backend."
+            )
+
+        previous_index_type = row.index_type
+        row.index_type = index_type
+        row.details = dict(metadata)
+        session.add(row)
+        session.commit()
+        session.refresh(row)
+        self.embedding_storage_managers.pop(model_name, None)
+
+        if previous_index_type != index_type:
+            obsolete_index_dir = self.get_safe_model_dir(model_name) / f"index_{previous_index_type.value}"
+            if obsolete_index_dir.exists():
+                logger.info(
+                    "Deleting obsolete FAISS index directory for model '%s': %s",
+                    model_name,
+                    obsolete_index_dir,
                 )
+                shutil.rmtree(obsolete_index_dir)
+
+        return self._record_from_registry_row(row)
 
     def _validate_storage_consistency(
         self,
@@ -287,6 +418,7 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
             model_name=model_name,
             dimensions=model_record.dimensions,
             index_type=model_record.index_type,
+            metadata=model_record.metadata,
         )
         self._validate_storage_consistency(
             session=session,
@@ -336,6 +468,7 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
             model_name=model_name,
             dimensions=model_record.dimensions,
             index_type=model_record.index_type,
+            metadata=model_record.metadata,
         )
 
         if storage_manager.get_count() == 0:
@@ -349,7 +482,7 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
         self.validate_embeddings(embeddings=query_embeddings, dimensions=model_record.dimensions)
         embedding_table = self._get_embedding_table(session, model_name)
 
-        if concept_filter is None:
+        if concept_filter is None or self._filter_is_empty(concept_filter):
             # Easier to not do any filter if all are allowed
             permitted_concept_ids = None
         else:
@@ -432,6 +565,7 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
             model_name=model_name,
             dimensions=model_record.dimensions,
             index_type=model_record.index_type,
+            metadata=model_record.metadata,
         )
         self._validate_storage_consistency(
             session=session,
@@ -473,6 +607,7 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
             model_name=model_name,
             dimensions=model_record.dimensions,
             index_type=model_record.index_type,
+            metadata=model_record.metadata,
         )
 
         return storage_manager.get_embeddings_by_concept_ids(concept_ids=concept_ids_np)

--- a/src/omop_emb/backends/faiss/faiss_backend.py
+++ b/src/omop_emb/backends/faiss/faiss_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+import shutil
 from typing import Any, Mapping, Optional, Sequence, Type, cast, Dict, Tuple 
 
 import numpy as np
@@ -186,6 +187,20 @@ class FaissEmbeddingBackend(EmbeddingBackend[FAISSConceptIDEmbeddingRegistry]):
             #metadata=faiss_metadata.to_dict(),
             metadata=metadata
         )
+
+    def delete_model(
+        self,
+        *,
+        engine: Engine,
+        session: Session,
+        model_name: str,
+    ) -> bool:
+        deleted = super().delete_model(engine=engine, session=session, model_name=model_name)
+        self.embedding_storage_managers.pop(model_name, None)
+        model_dir = self.get_safe_model_dir(model_name)
+        if model_dir.exists():
+            shutil.rmtree(model_dir)
+        return deleted
 
     @require_registered_model
     def upsert_embeddings(

--- a/src/omop_emb/backends/faiss/faiss_sql.py
+++ b/src/omop_emb/backends/faiss/faiss_sql.py
@@ -11,7 +11,7 @@ from omop_alchemy.cdm.model.vocabulary import Concept
 
 from ..base import ConceptIDEmbeddingBase
 from ..config import BackendType
-from ..registry import ModelRegistry
+from ..registry import ModelRegistry, get_metadata_schema
 from ..embedding_utils import EmbeddingConceptFilter
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,10 @@ def create_faiss_embedding_registry_table(
         (FAISSConceptIDEmbeddingRegistry, ),
         {
             "__tablename__": tablename,
-            "__table_args__": {"extend_existing": True},
+            "__table_args__": {
+                "extend_existing": True,
+                "schema": get_metadata_schema(),
+            },
         },
     )
     

--- a/src/omop_emb/backends/faiss/index_manager.py
+++ b/src/omop_emb/backends/faiss/index_manager.py
@@ -115,7 +115,18 @@ class BaseIndexManager(abc.ABC):
         """
         query = self._prepare_vectors(query_vector)
         params = self._create_search_parameters(subset_concept_ids)
+        started_at = time.monotonic()
         distances, concept_ids = self.index.search(query, k=k, params=params)  # type: ignore
+        elapsed_seconds = time.monotonic() - started_at
+        logger.info(
+            "Completed FAISS search: index_type=%s metric=%s queries=%s k=%s subset_size=%s elapsed=%.3fs",
+            self.supported_index_type.value,
+            self.metric_type.value,
+            query.shape[0],
+            k,
+            None if subset_concept_ids is None else int(len(subset_concept_ids)),
+            elapsed_seconds,
+        )
 
         if self.metric_type == MetricType.L2:
             # https://github.com/facebookresearch/faiss/wiki/MetricType-and-distances#metric_l2
@@ -142,7 +153,18 @@ class BaseIndexManager(abc.ABC):
 
     def load(self):
         """Loads an index from disk."""
+        started_at = time.monotonic()
         self._index = faiss.read_index(str(self.index_filepath))
+        elapsed_seconds = time.monotonic() - started_at
+        ntotal = getattr(self._index, "ntotal", "unknown")
+        logger.info(
+            "Loaded FAISS index from disk at %s (index_type=%s metric=%s ntotal=%s elapsed=%.3fs).",
+            self.index_filepath,
+            self.supported_index_type.value,
+            self.metric_type.value,
+            ntotal,
+            elapsed_seconds,
+        )
 
     def load_or_populate(self, data_stream: Generator[Tuple[np.ndarray, np.ndarray], None, None]):
         """Loads the index from disk if it exists, otherwise populates it from the provided data stream."""

--- a/src/omop_emb/backends/faiss/index_manager.py
+++ b/src/omop_emb/backends/faiss/index_manager.py
@@ -14,8 +14,10 @@ logger = logging.getLogger(__name__)
 def logger_warning_partial_index_population(filepath: Path):
     logger.warning(
         "Current implementation does not guarantee that indices on disk are fully populated "
-        "or consistent with the raw embedding storage.\nIf you want to "
-        f"re-populate from storage, please delete the existing index file at `{filepath}` first.\n\n"
+        "or consistent with the raw embedding storage in embeddings.h5.\n"
+        "If you want to rebuild from HDF5, run `omop-emb rebuild-index` for the relevant "
+        "model, backend, and metric.\n"
+        f"Loaded existing index file: `{filepath}`.\n"
     )
 
 class BaseIndexManager(abc.ABC):

--- a/src/omop_emb/backends/faiss/index_manager.py
+++ b/src/omop_emb/backends/faiss/index_manager.py
@@ -142,6 +142,14 @@ class BaseIndexManager(abc.ABC):
             logger.info(f"No index file found at {self.index_filepath}, populating index from storage.")
             self._populate_from_storage(data_stream)
 
+    def rebuild_from_storage(self, data_stream: Generator[Tuple[np.ndarray, np.ndarray], None, None]):
+        """Delete any persisted index file and rebuild it from the provided storage stream."""
+        if self.has_index_on_disk():
+            logger.info("Deleting existing FAISS index before rebuild: %s", self.index_filepath)
+            self.index_filepath.unlink()
+        self._index = None
+        self._populate_from_storage(data_stream)
+
     def _populate_from_storage(
         self, 
         data_stream: Generator[Tuple[np.ndarray, np.ndarray], None, None]
@@ -214,23 +222,45 @@ class HNSWIndexManager(BaseIndexManager):
         dimension: int, 
         metric_type: MetricType,
         base_index_dir: str | Path,
-        num_neighbors: int = 32
+        num_neighbors: int = 32,
+        ef_search: int = 64,
+        ef_construction: int = 200,
     ):
-        super().__init__(dimension, metric_type, base_index_dir)
         self.num_neighbors = num_neighbors
-        
-    #def _create_index(self) -> faiss.Index:
-    #    if self.metric == MetricType.L2:
-    #        return faiss.IndexHNSWFlat(self.dimension, self.num_neighbors)
-    #    elif self.metric == MetricType.COSINE:
-    #        # Inner Product for Cosine similarity after normalization
-    #        return faiss.IndexHNSWFlat(self.dimension, self.num_neighbors, faiss.METRIC_INNER_PRODUCT)  
-    #    else:
-    #        raise ValueError(f"Unsupported metric {self.metric} for HNSW index.")
+        self.ef_search = ef_search
+        self.ef_construction = ef_construction
+        super().__init__(dimension, metric_type, base_index_dir)
+
+    def _create_index(self) -> faiss.Index:
+        if self.metric_type == MetricType.L2:
+            index = faiss.IndexHNSWFlat(self.dimension, self.num_neighbors, faiss.METRIC_L2)
+        elif self.metric_type == MetricType.COSINE:
+            index = faiss.IndexHNSWFlat(self.dimension, self.num_neighbors, faiss.METRIC_INNER_PRODUCT)
+        else:
+            raise ValueError(f"Unsupported metric {self.metric_type} for HNSW index.")
+
+        index.hnsw.efConstruction = self.ef_construction  # type: ignore[attr-defined]
+        index.hnsw.efSearch = self.ef_search  # type: ignore[attr-defined]
+        return index
         
     @property
     def supported_index_type(self) -> IndexType:
         return IndexType.HNSW
+
+    def _create_search_parameters(self, concept_id_subset: np.ndarray | None = None):
+        if hasattr(faiss, "SearchParametersHNSW"):
+            params = faiss.SearchParametersHNSW()  # type: ignore[attr-defined]
+            params.efSearch = self.ef_search  # type: ignore[attr-defined]
+            if concept_id_subset is not None:
+                self.validate_concept_ids(concept_id_subset)
+                params.sel = faiss.IDSelectorBatch(concept_id_subset)  # type: ignore[attr-defined]
+            return params
+
+        if concept_id_subset is not None:
+            self.validate_concept_ids(concept_id_subset)
+            id_selector = faiss.IDSelectorBatch(concept_id_subset)  # type: ignore
+            return faiss.SearchParameters(sel=id_selector)  # type: ignore
+        return faiss.SearchParameters()
     
 class IVFIndexManager(BaseIndexManager):
     def __init__(

--- a/src/omop_emb/backends/faiss/index_manager.py
+++ b/src/omop_emb/backends/faiss/index_manager.py
@@ -4,6 +4,7 @@ This module is closely tied to the storage manager, as it needs to know how to r
 import faiss
 import numpy as np
 import abc
+import time
 from pathlib import Path
 from typing import Optional, Generator, Tuple
 
@@ -128,7 +129,16 @@ class BaseIndexManager(abc.ABC):
 
     def save(self):
         """Saves the index to disk."""
+        ntotal = getattr(self.index, "ntotal", "unknown")
+        logger.info(
+            "Writing FAISS index to disk at %s (index_type=%s metric=%s ntotal=%s).",
+            self.index_filepath,
+            self.supported_index_type.value,
+            self.metric_type.value,
+            ntotal,
+        )
         faiss.write_index(self.index, str(self.index_filepath))
+        logger.info("Completed writing FAISS index to disk at %s.", self.index_filepath)
 
     def load(self):
         """Loads an index from disk."""
@@ -170,8 +180,30 @@ class BaseIndexManager(abc.ABC):
             logger_warning_partial_index_population(self.index_filepath)
         else:
             logger.info(f"Populating {self.supported_index_type.value} from storage with data stream. This may take a while for large datasets...")
+            started_at = time.monotonic()
+            processed_vectors = 0
+            batch_count = 0
             for concept_ids, embeddings in data_stream:
                 self.add(concept_ids, embeddings)
+                batch_count += 1
+                processed_vectors += int(len(concept_ids))
+                if batch_count == 1 or batch_count % 10 == 0:
+                    elapsed_seconds = time.monotonic() - started_at
+                    logger.info(
+                        "FAISS index build progress: index_type=%s metric=%s batches=%s vectors=%s elapsed=%.1fs",
+                        self.supported_index_type.value,
+                        self.metric_type.value,
+                        batch_count,
+                        processed_vectors,
+                        elapsed_seconds,
+                    )
+            logger.info(
+                "Completed populating FAISS index in memory: index_type=%s metric=%s batches=%s vectors=%s. Saving index to disk next.",
+                self.supported_index_type.value,
+                self.metric_type.value,
+                batch_count,
+                processed_vectors,
+            )
             self.save()
 
     def validate_embedding_vector(self, vector: np.ndarray):

--- a/src/omop_emb/backends/faiss/storage_manager.py
+++ b/src/omop_emb/backends/faiss/storage_manager.py
@@ -33,7 +33,9 @@ class EmbeddingStorageManager:
         file_dir: str | Path, 
         dimensions: int,
         backend_type: BackendType,
-        # NOTE: Add neighbours/clusters here as param if differently support index types
+        hnsw_num_neighbors: int = 32,
+        hnsw_ef_search: int = 64,
+        hnsw_ef_construction: int = 200,
     ):
         # Sanity check
         if backend_type != BackendType.FAISS:
@@ -41,6 +43,9 @@ class EmbeddingStorageManager:
 
         self.base_dir = Path(file_dir)
         self.dimensions = dimensions
+        self.hnsw_num_neighbors = hnsw_num_neighbors
+        self.hnsw_ef_search = hnsw_ef_search
+        self.hnsw_ef_construction = hnsw_ef_construction
         self._init_embedding_storage_if_missing()
         self._index_managers: Dict[IndexType, Dict[MetricType, BaseIndexManager]] = {}
 
@@ -81,11 +86,21 @@ class EmbeddingStorageManager:
                 f"Supported indices are {IndexType.FLAT} and {IndexType.HNSW}."
             )
         
-        index_manager = index_manager_cls(
-            dimension=self.dimensions,
-            metric_type=metric_type,
-            base_index_dir=self.base_dir
-        )
+        if index_type == IndexType.HNSW:
+            index_manager = index_manager_cls(
+                dimension=self.dimensions,
+                metric_type=metric_type,
+                base_index_dir=self.base_dir,
+                num_neighbors=self.hnsw_num_neighbors,
+                ef_search=self.hnsw_ef_search,
+                ef_construction=self.hnsw_ef_construction,
+            )
+        else:
+            index_manager = index_manager_cls(
+                dimension=self.dimensions,
+                metric_type=metric_type,
+                base_index_dir=self.base_dir,
+            )
 
         index_manager.load_or_populate(
             self.stream_concept_ids_and_embeddings(batch_size=batch_size)

--- a/src/omop_emb/backends/faiss/storage_manager.py
+++ b/src/omop_emb/backends/faiss/storage_manager.py
@@ -69,12 +69,12 @@ class EmbeddingStorageManager:
             )
             self._index_managers[index_type][metric_type] = index_manager
         return self._index_managers[index_type][metric_type]
-    
-    def create_index_manager(
+
+    def _instantiate_index_manager(
         self,
+        *,
         index_type: IndexType,
         metric_type: MetricType,
-        batch_size: int = 100_000
     ) -> BaseIndexManager:
         if index_type == IndexType.FLAT:
             index_manager_cls = FlatIndexManager
@@ -85,9 +85,9 @@ class EmbeddingStorageManager:
                 f"Unsupported index type {index_type} for FAISS backend. "
                 f"Supported indices are {IndexType.FLAT} and {IndexType.HNSW}."
             )
-        
+
         if index_type == IndexType.HNSW:
-            index_manager = index_manager_cls(
+            return index_manager_cls(
                 dimension=self.dimensions,
                 metric_type=metric_type,
                 base_index_dir=self.base_dir,
@@ -95,13 +95,23 @@ class EmbeddingStorageManager:
                 ef_search=self.hnsw_ef_search,
                 ef_construction=self.hnsw_ef_construction,
             )
-        else:
-            index_manager = index_manager_cls(
-                dimension=self.dimensions,
-                metric_type=metric_type,
-                base_index_dir=self.base_dir,
-            )
 
+        return index_manager_cls(
+            dimension=self.dimensions,
+            metric_type=metric_type,
+            base_index_dir=self.base_dir,
+        )
+    
+    def create_index_manager(
+        self,
+        index_type: IndexType,
+        metric_type: MetricType,
+        batch_size: int = 100_000
+    ) -> BaseIndexManager:
+        index_manager = self._instantiate_index_manager(
+            index_type=index_type,
+            metric_type=metric_type,
+        )
         index_manager.load_or_populate(
             self.stream_concept_ids_and_embeddings(batch_size=batch_size)
         )
@@ -235,7 +245,15 @@ class EmbeddingStorageManager:
         metric_type: MetricType,
         batch_size: int = 100_000,
     ) -> None:
-        index_manager = self.get_index_manager(index_type=index_type, metric_type=metric_type)
+        if index_type not in self._index_managers:
+            self._index_managers[index_type] = {}
+        index_manager = self._index_managers[index_type].get(metric_type)
+        if index_manager is None:
+            index_manager = self._instantiate_index_manager(
+                index_type=index_type,
+                metric_type=metric_type,
+            )
+            self._index_managers[index_type][metric_type] = index_manager
         index_manager.rebuild_from_storage(
             self.stream_concept_ids_and_embeddings(batch_size=batch_size)
         )

--- a/src/omop_emb/backends/faiss/storage_manager.py
+++ b/src/omop_emb/backends/faiss/storage_manager.py
@@ -12,7 +12,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from omop_emb.backends.config import BackendType, IndexType, MetricType
-from .index_manager import FlatIndexManager, BaseIndexManager
+from .index_manager import FlatIndexManager, HNSWIndexManager, BaseIndexManager
 
 class EmbeddingStorageManager:
     """Storage manager for raw embeddings and concept_ids using HDF5 files for FAISS backend. 
@@ -73,8 +73,13 @@ class EmbeddingStorageManager:
     ) -> BaseIndexManager:
         if index_type == IndexType.FLAT:
             index_manager_cls = FlatIndexManager
+        elif index_type == IndexType.HNSW:
+            index_manager_cls = HNSWIndexManager
         else:
-            raise ValueError(f"Unsupported index type {index_type} for FAISS backend. Only {IndexType.FLAT} is supported currently.")
+            raise ValueError(
+                f"Unsupported index type {index_type} for FAISS backend. "
+                f"Supported indices are {IndexType.FLAT} and {IndexType.HNSW}."
+            )
         
         index_manager = index_manager_cls(
             dimension=self.dimensions,
@@ -152,10 +157,6 @@ class EmbeddingStorageManager:
         if len(unique) != len(concept_ids):
             raise ValueError("Duplicate concept_ids found in the input. Please ensure all concept_ids are unique to prevent data corruption.")
 
-        existing_concept_ids = self.get_concept_ids()
-        if np.intersect1d(existing_concept_ids, concept_ids).size > 0:
-            raise ValueError("Some concept_ids already exist in storage. Appending duplicate concept_ids would corrupt the data. Please ensure all concept_ids are unique and do not already exist in storage.")
-
         with self.open_all(mode="a") as (emb_ds, cid_ds):
             # 1. Calculate new sizes
             old_size = emb_ds.shape[0]
@@ -210,6 +211,18 @@ class EmbeddingStorageManager:
             query_vector=query_vector,
             k=k,
             subset_concept_ids=subset_concept_ids
+        )
+
+    def rebuild_index(
+        self,
+        *,
+        index_type: IndexType,
+        metric_type: MetricType,
+        batch_size: int = 100_000,
+    ) -> None:
+        index_manager = self.get_index_manager(index_type=index_type, metric_type=metric_type)
+        index_manager.rebuild_from_storage(
+            self.stream_concept_ids_and_embeddings(batch_size=batch_size)
         )
     
     def get_embeddings_by_concept_ids(self, concept_ids: np.ndarray) -> Mapping[int, Sequence[float]]:

--- a/src/omop_emb/backends/pgvector/pgvector_sql.py
+++ b/src/omop_emb/backends/pgvector/pgvector_sql.py
@@ -12,7 +12,7 @@ import logging
 from numpy import ndarray
 
 from ..config import BackendType, IndexType, MetricType
-from ..registry import ModelRegistry
+from ..registry import ModelRegistry, get_metadata_schema
 from ..base import ConceptIDEmbeddingBase
 from ..embedding_utils import EmbeddingConceptFilter, get_similarity_from_distance
 
@@ -39,14 +39,23 @@ def create_pg_embedding_table(
             "__tablename__": tablename,
             # We override the attribute with the specific dimension-aware column
             "embedding": mapped_column(Vector(dimensions), nullable=False, index=False),
-            "__table_args__": {"extend_existing": True},
+            "__table_args__": {
+                "extend_existing": True,
+                "schema": get_metadata_schema(),
+            },
         }
     )
     Base.metadata.create_all(engine, tables=[table.__table__])  # type: ignore[arg-type]
 
     with engine.connect() as conn:
         inspector = inspect(conn)
-        existing_indexes = [idx['name'] for idx in inspector.get_indexes(model_registry_entry.storage_identifier)]
+        existing_indexes = [
+            idx["name"]
+            for idx in inspector.get_indexes(
+                model_registry_entry.storage_identifier,
+                schema=get_metadata_schema(),
+            )
+        ]
         
         create_index_sql = _create_index_sql(
             model_registry_entry.storage_identifier,
@@ -100,6 +109,9 @@ def add_embeddings_to_registered_table(
 
 
 def _create_index_sql(table_name: str, index_type: IndexType) -> Optional[str]:
+    schema = get_metadata_schema()
+    qualified_table_name = f'"{schema}"."{table_name}"'
+    qualified_index_name = f'"{schema}"."{_index_from_storage_identifier(table_name)}"'
     if index_type == IndexType.FLAT:
         pass # No additional index needed for flat, as the vector column itself can be used for sequential scan
     else:

--- a/src/omop_emb/backends/registry.py
+++ b/src/omop_emb/backends/registry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from sqlalchemy import DateTime, Engine, Integer, JSON, String, func, inspect, text, Enum
 from sqlalchemy.orm import mapped_column, validates
 
@@ -11,6 +13,13 @@ from .config import (
     IndexType, 
     BackendType
 )
+
+
+ENV_OMOP_EMB_METADATA_SCHEMA = "OMOP_EMB_METADATA_SCHEMA"
+
+
+def get_metadata_schema() -> str:
+    return os.getenv(ENV_OMOP_EMB_METADATA_SCHEMA, "public")
 
 class ModelRegistry(Base):
     """
@@ -25,6 +34,7 @@ class ModelRegistry(Base):
     """
 
     __tablename__ = "model_registry"
+    __table_args__ = {"schema": get_metadata_schema()}
 
     # TODO: Think about having multiple models per index and backend. Would require to 
     # have the storage_identifier (i.e. the table_name) to be unique as well, which is 
@@ -55,4 +65,8 @@ class ModelRegistry(Base):
 
 
 def ensure_model_registry_schema(engine: Engine) -> None:
+    schema = get_metadata_schema()
+    if schema:
+        with engine.begin() as conn:
+            conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
     Base.metadata.create_all(engine, tables=[ModelRegistry.__table__])  # type: ignore[arg-type]

--- a/src/omop_emb/backends/registry.py
+++ b/src/omop_emb/backends/registry.py
@@ -50,7 +50,9 @@ class ModelRegistry(Base):
 
     @validates("index_type")
     def validate_index_for_backend(self, key, index_type):
-        if is_index_type_supported_for_backend(self.backend_type, index_type):
+        if self.backend_type is None:
+            return index_type
+        if not is_index_type_supported_for_backend(self.backend_type, index_type):
             raise ValueError(
                 f"Backend {self.backend_type} does not support {index_type}. "
                 f"Supported: {get_supported_index_types_for_backend(self.backend_type)}"

--- a/src/omop_emb/cli.py
+++ b/src/omop_emb/cli.py
@@ -136,6 +136,10 @@ def add_embeddings(
         "--embedding-path",
         help="Embedding endpoint path relative to `--api-base`, for example `/embeddings` or `/embed`. Can also be set with `OMOP_EMB_EMBEDDING_PATH`."
     )] = "/embeddings",
+    overwrite_model_registration: Annotated[bool, typer.Option(
+        "--overwrite-model-registration",
+        help="If set, delete any existing registration and backend storage for this model name before re-registering it. Use with care when changing dimensions or endpoint behavior."
+    )] = False,
     backend_name: Annotated[Optional[str], typer.Option(
         "--backend",
         help="Embedding backend to use. Can be replaced by the `OMOP_EMB_BACKEND` environment variable."
@@ -202,7 +206,8 @@ def add_embeddings(
             session=reader,
             model_name=resolved_model,
             index_type=index_type,
-            dimensions=resolved_embedding_dim
+            dimensions=resolved_embedding_dim,
+            overwrite_existing_conflicts=overwrite_model_registration,
         )
 
         estimated_total_concepts = num_embeddings or interface.get_concepts_without_embedding_count(

--- a/src/omop_emb/cli.py
+++ b/src/omop_emb/cli.py
@@ -389,5 +389,51 @@ def search(
         )
 
 
+@app.command("rebuild-index")
+def rebuild_index(
+    model: Annotated[Optional[str], typer.Option(
+        "--model", "-m",
+        help="Registered embedding model name to rebuild indexes for."
+    )] = None,
+    backend_name: Annotated[Optional[str], typer.Option(
+        "--backend",
+        help="Embedding backend to rebuild. Currently only FAISS supports explicit rebuild."
+    )] = None,
+    faiss_base_dir: Annotated[Optional[str], typer.Option(
+        "--faiss-base-dir",
+        help="Optional base directory for FAISS backend storage."
+    )] = None,
+    metric_types: Annotated[Optional[list[MetricType]], typer.Option(
+        "--metric-type",
+        help="Metric(s) to rebuild. Repeat to rebuild multiple metrics. Defaults to all metrics supported by the model's index type."
+    )] = None,
+    batch_size: Annotated[int, typer.Option(
+        "--batch-size", "-b",
+        help="Batch size to use when streaming embeddings from disk during rebuild."
+    )] = 100_000,
+):
+    configure_logging()
+    load_dotenv()
+
+    engine = _create_engine_from_env()
+    logger.info("Embedding metadata schema: %s", get_metadata_schema())
+    interface = EmbeddingInterface.from_backend_name(
+        backend_name=backend_name,
+        faiss_base_dir=faiss_base_dir,
+    )
+    resolved_model = _resolve_model_name(model)
+    interface.initialise_store(engine)
+
+    with Session(engine) as session:
+        interface.rebuild_model_indexes(
+            session=session,
+            model_name=resolved_model,
+            metric_types=tuple(metric_types) if metric_types else None,
+            batch_size=batch_size,
+        )
+
+    logger.info("Completed index rebuild for model '%s'.", resolved_model)
+
+
 if __name__ == "__main__":
     app()

--- a/src/omop_emb/cli.py
+++ b/src/omop_emb/cli.py
@@ -14,7 +14,7 @@ from omop_emb.backends import (
 )
 from omop_emb.embedding_client import OpenAICompatibleEmbeddingClient
 from omop_emb.interface import EmbeddingInterface
-from omop_emb.backends.config import IndexType
+from omop_emb.backends.config import IndexType, MetricType
 
 app = typer.Typer()
 logger = get_logger(__name__)
@@ -107,6 +107,48 @@ def _compile_sql(query: sa.Select, engine: sa.Engine) -> str:
         return str(query)
 
 
+def _create_engine_from_env() -> sa.Engine:
+    engine_string = os.getenv('OMOP_DATABASE_URL')
+    if engine_string is None:
+        raise RuntimeError("OMOP_DATABASE_URL environment variable not set. Please set it in your .env file to point to your database.")
+
+    engine = sa.create_engine(engine_string, future=True, echo=False)
+    assert engine.dialect.name == "postgresql", "Only PostgreSQL databases are supported for embedding storage with the current backends. Please check your `OMOP_DATABASE_URL` environment variable and ensure it points to a PostgreSQL database."
+    return engine
+
+
+def _create_embedding_interface(
+    *,
+    api_base: str,
+    api_key: Optional[str],
+    batch_size: int,
+    model: Optional[str],
+    backend_name: Optional[str],
+    faiss_base_dir: Optional[str],
+    embedding_path: str,
+) -> tuple[EmbeddingInterface, str]:
+    resolved_embedding_path = _normalize_embedding_path(
+        os.getenv("OMOP_EMB_EMBEDDING_PATH") or embedding_path
+    )
+    resolved_api_base = _normalize_api_base(api_base, resolved_embedding_path)
+    resolved_api_key = _resolve_api_key(api_key)
+    resolved_model = _resolve_model_name(model)
+
+    interface = EmbeddingInterface.from_backend_name(
+        backend_name=backend_name,
+        faiss_base_dir=faiss_base_dir,
+        embedding_client=OpenAICompatibleEmbeddingClient(
+            model=resolved_model,
+            api_base=resolved_api_base,
+            api_key=resolved_api_key,
+            embedding_batch_size=batch_size,
+            embedding_path=resolved_embedding_path,
+            encoding_format="float",
+        ),
+    )
+    return interface, resolved_model
+
+
 @app.command()
 def add_embeddings(
     api_base: Annotated[str, typer.Option(
@@ -163,32 +205,15 @@ def add_embeddings(
 ):
     configure_logging()
     load_dotenv()
-
-    engine_string = os.getenv('OMOP_DATABASE_URL')
-    if engine_string is None:
-        raise RuntimeError("OMOP_DATABASE_URL environment variable not set. Please set it in your .env file to point to your database.")
-    
-    resolved_embedding_path = _normalize_embedding_path(
-        os.getenv("OMOP_EMB_EMBEDDING_PATH") or embedding_path
-    )
-    resolved_api_base = _normalize_api_base(api_base, resolved_embedding_path)
-    resolved_api_key = _resolve_api_key(api_key)
-
-    engine = sa.create_engine(engine_string, future=True, echo=False)
-    assert engine.dialect.name == "postgresql", "Only PostgreSQL databases are supported for embedding storage with the current backends. Please check your `OMOP_DATABASE_URL` environment variable and ensure it points to a PostgreSQL database."
-    resolved_model = _resolve_model_name(model)
-
-    interface = EmbeddingInterface.from_backend_name(
+    engine = _create_engine_from_env()
+    interface, resolved_model = _create_embedding_interface(
+        api_base=api_base,
+        api_key=api_key,
+        batch_size=batch_size,
+        model=model,
         backend_name=backend_name,
         faiss_base_dir=faiss_base_dir,
-        embedding_client=OpenAICompatibleEmbeddingClient(
-            model=resolved_model,
-            api_base=resolved_api_base,
-            api_key=resolved_api_key,
-            embedding_batch_size=batch_size,
-            embedding_path=resolved_embedding_path,
-            encoding_format="float",
-        ),
+        embedding_path=embedding_path,
     )
     resolved_embedding_dim = _resolve_embedding_dim(interface, embedding_dim)
 
@@ -267,6 +292,98 @@ def add_embeddings(
                 pbar.update(len(batch_concepts))
 
     logger.info("Completed embedding generation and storage. Wrote %s embeddings.", processed_concepts)
+
+
+@app.command()
+def search(
+    query_text: Annotated[str, typer.Argument(
+        help="Text to embed and search against stored concept embeddings."
+    )],
+    api_base: Annotated[str, typer.Option(
+        "--api-base",
+        help="Base URL for the API to use for generating query embeddings.",
+    )],
+    api_key: Annotated[Optional[str], typer.Option(
+        "--api-key",
+        help="Optional API key for the embedding API. Can also be set with `OMOP_EMB_API_KEY`."
+    )] = None,
+    batch_size: Annotated[int, typer.Option(
+        "--batch-size", "-b",
+        help="Batch size to use when generating query embeddings."
+    )] = 32,
+    model: Annotated[Optional[str], typer.Option(
+        "--model", "-m",
+        help="Name of the embedding model to query."
+    )] = None,
+    embedding_path: Annotated[str, typer.Option(
+        "--embedding-path",
+        help="Embedding endpoint path relative to `--api-base`, for example `/embeddings` or `/embed`."
+    )] = "/embeddings",
+    backend_name: Annotated[Optional[str], typer.Option(
+        "--backend",
+        help="Embedding backend to query. Can be replaced by the `OMOP_EMB_BACKEND` environment variable."
+    )] = None,
+    faiss_base_dir: Annotated[Optional[str], typer.Option(
+        "--faiss-base-dir",
+        help="Optional base directory for FAISS backend storage."
+    )] = None,
+    metric_type: Annotated[MetricType, typer.Option(
+        "--metric-type",
+        help="Similarity or distance metric to use for nearest-neighbor search."
+    )] = MetricType.COSINE,
+    k: Annotated[int, typer.Option(
+        "--k",
+        help="Number of nearest concepts to return."
+    )] = 10,
+    standard_only: Annotated[bool, typer.Option(
+        "--standard-only",
+        help="If set, only search within OMOP standard concepts."
+    )] = False,
+    vocabularies: Annotated[Optional[list[str]], typer.Option(
+        "--vocabulary",
+        help="Optional vocabulary filter. Repeat to restrict the search space."
+    )] = None,
+):
+    configure_logging()
+    load_dotenv()
+
+    engine = _create_engine_from_env()
+    interface, resolved_model = _create_embedding_interface(
+        api_base=api_base,
+        api_key=api_key,
+        batch_size=batch_size,
+        model=model,
+        backend_name=backend_name,
+        faiss_base_dir=faiss_base_dir,
+        embedding_path=embedding_path,
+    )
+    concept_filter = EmbeddingConceptFilter(
+        require_standard=standard_only,
+        vocabularies=tuple(vocabularies) if vocabularies else None,
+    )
+
+    interface.initialise_store(engine)
+
+    with Session(engine) as session:
+        query_embeddings = interface.embed_texts(query_text, batch_size=batch_size)
+        matches = interface.backend.get_nearest_concepts(
+            session=session,
+            model_name=resolved_model,
+            query_embeddings=query_embeddings,
+            metric_type=metric_type,
+            concept_filter=concept_filter,
+            k=k,
+        )
+
+    typer.echo("rank\tconcept_id\tsimilarity\tconcept_name")
+    if not matches or not matches[0]:
+        logger.info("No search results found for model '%s'.", resolved_model)
+        return
+
+    for rank, match in enumerate(matches[0], start=1):
+        typer.echo(
+            f"{rank}\t{match.concept_id}\t{match.similarity:.6f}\t{match.concept_name}"
+        )
 
 
 if __name__ == "__main__":

--- a/src/omop_emb/cli.py
+++ b/src/omop_emb/cli.py
@@ -15,6 +15,7 @@ from omop_emb.backends import (
 from omop_emb.embedding_client import OpenAICompatibleEmbeddingClient
 from omop_emb.interface import EmbeddingInterface
 from omop_emb.backends.config import IndexType, MetricType
+from omop_emb.backends.registry import get_metadata_schema
 
 app = typer.Typer()
 logger = get_logger(__name__)
@@ -206,6 +207,7 @@ def add_embeddings(
     configure_logging()
     load_dotenv()
     engine = _create_engine_from_env()
+    logger.info("Embedding metadata schema: %s", get_metadata_schema())
     interface, resolved_model = _create_embedding_interface(
         api_base=api_base,
         api_key=api_key,
@@ -348,6 +350,7 @@ def search(
     load_dotenv()
 
     engine = _create_engine_from_env()
+    logger.info("Embedding metadata schema: %s", get_metadata_schema())
     interface, resolved_model = _create_embedding_interface(
         api_base=api_base,
         api_key=api_key,

--- a/src/omop_emb/cli.py
+++ b/src/omop_emb/cli.py
@@ -4,7 +4,6 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
 from orm_loader.helpers import get_logger, configure_logging, create_db
-from omop_alchemy.cdm.model.vocabulary import Concept
 
 from typing import Annotated, Optional
 import os
@@ -16,10 +15,54 @@ from omop_emb.backends import (
     EmbeddingConceptFilter,
 )
 from omop_emb.interface import EmbeddingInterface
-from omop_emb.backends.config import BackendType, IndexType
+from omop_emb.backends.config import IndexType
 
 app = typer.Typer()
 logger = get_logger(__name__)
+
+
+def _resolve_model_name(model: Optional[str]) -> str:
+    resolved_model = model or os.getenv("OMOP_EMB_MODEL") or "text-embedding-3-small"
+    if not resolved_model:
+        raise RuntimeError(
+            "No embedding model configured. Pass `--model` or set `OMOP_EMB_MODEL`."
+        )
+    return resolved_model
+
+
+def _resolve_embedding_dim(
+    interface: EmbeddingInterface,
+    embedding_dim: Optional[int],
+) -> int:
+    if embedding_dim is None:
+        raw_dim = os.getenv("OMOP_EMB_EMBEDDING_DIM")
+        if raw_dim:
+            try:
+                embedding_dim = int(raw_dim)
+            except ValueError as exc:
+                raise RuntimeError(
+                    "OMOP_EMB_EMBEDDING_DIM must be an integer."
+                ) from exc
+
+    if embedding_dim is not None:
+        if embedding_dim <= 0:
+            raise RuntimeError("Embedding dimension override must be a positive integer.")
+        return embedding_dim
+
+    try:
+        resolved_dim = interface.embedding_dim
+    except NotImplementedError as exc:
+        raise RuntimeError(
+            "Embedding dimension could not be inferred from the configured API client. "
+            "Pass `--embedding-dim` or set `OMOP_EMB_EMBEDDING_DIM`."
+        ) from exc
+
+    if resolved_dim is None:
+        raise RuntimeError(
+            "Embedding dimensions could not be determined from the embedding client. "
+            "Pass `--embedding-dim` or set `OMOP_EMB_EMBEDDING_DIM`."
+        )
+    return resolved_dim
 
 
 @app.command()
@@ -38,9 +81,14 @@ def add_embeddings(
     batch_size: Annotated[int, typer.Option(
         "--batch-size", "-b",
         help="Batch size to use when generating and inserting embeddings. Adjust based on your system's memory capacity.")] = 100,
-    model: Annotated[str, typer.Option(
+    model: Annotated[Optional[str], typer.Option(
         "--model", "-m",
-        help="Name of the embedding model to use for generating concept embeddings (e.g., 'text-embedding-3-small'). If not provided, embeddings will not be generated.")] = "text-embedding-3-small",
+        help="Name of the embedding model to use for generating concept embeddings. Can also be set with `OMOP_EMB_MODEL`."
+    )] = None,
+    embedding_dim: Annotated[Optional[int], typer.Option(
+        "--embedding-dim",
+        help="Explicit embedding dimension for the configured model. Use this for OpenAI-compatible endpoints when the client cannot infer dimensions automatically. Can also be set with `OMOP_EMB_EMBEDDING_DIM`."
+    )] = None,
     backend_name: Annotated[Optional[str], typer.Option(
         "--backend",
         help="Embedding backend to use. Can be replaced by the `OMOP_EMB_BACKEND` environment variable."
@@ -71,19 +119,19 @@ def add_embeddings(
     
     engine = sa.create_engine(engine_string, future=True, echo=False)
     assert engine.dialect.name == "postgresql", "Only PostgreSQL databases are supported for embedding storage with the current backends. Please check your `OMOP_DATABASE_URL` environment variable and ensure it points to a PostgreSQL database."
+    resolved_model = _resolve_model_name(model)
 
     interface = EmbeddingInterface.from_backend_name(
         backend_name=backend_name,
         faiss_base_dir=faiss_base_dir,
         embedding_client=LLMClient(
-            model=model,
+            model=resolved_model,
             api_base=api_base,
             api_key=api_key,
             embedding_batch_size=batch_size
         ),
     )
-    embedding_dim = interface.embedding_dim
-    assert embedding_dim is not None, "Embedding dimensions could not be determined from the embedding client."
+    resolved_embedding_dim = _resolve_embedding_dim(interface, embedding_dim)
 
     concept_filter = EmbeddingConceptFilter(
         require_standard=standard_only,
@@ -98,19 +146,19 @@ def add_embeddings(
         interface.ensure_model_registered(
             engine=engine,
             session=reader,
-            model_name=model,
+            model_name=resolved_model,
             index_type=index_type,
-            dimensions=embedding_dim
+            dimensions=resolved_embedding_dim
         )
 
         total_concepts = num_embeddings or interface.get_concepts_without_embedding_count(
             session=reader,
-            model_name=model,
+            model_name=resolved_model,
             concept_filter=concept_filter,
         )
         concepts_without_embedding = interface.get_concepts_without_embedding_query(
             session=reader,
-            model_name=model,
+            model_name=resolved_model,
             concept_filter=concept_filter,
             limit=num_embeddings,
         )
@@ -124,7 +172,7 @@ def add_embeddings(
                 
                 interface.embed_and_upsert_concepts(
                     session=writer,
-                    model_name=model,
+                    model_name=resolved_model,
                     concept_ids=tuple(batch_concepts.keys()),
                     concept_texts=tuple(batch_concepts.values()),
                     batch_size=batch_size,

--- a/src/omop_emb/cli.py
+++ b/src/omop_emb/cli.py
@@ -3,7 +3,11 @@ from sqlalchemy.orm import Session
 
 from orm_loader.helpers import get_logger, configure_logging
 
-from typing import Annotated, Optional
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+from pathlib import Path
+import time
+from typing import Annotated, Optional, Sequence
 import os
 from dotenv import load_dotenv
 from tqdm import tqdm
@@ -26,6 +30,12 @@ from omop_emb.backends.registry import get_metadata_schema
 
 app = typer.Typer()
 logger = get_logger(__name__)
+
+
+def _log_timing(stage: str, started_at: float) -> float:
+    elapsed = time.monotonic() - started_at
+    logger.info("Timing: %s completed in %.3fs", stage, elapsed)
+    return elapsed
 
 
 def _resolve_model_name(model: Optional[str]) -> str:
@@ -189,6 +199,124 @@ def _create_embedding_interface(
         ),
     )
     return interface, resolved_model
+
+
+def _load_batch_queries(query_file: str) -> list[tuple[str, str]]:
+    loaded_queries: list[tuple[str, str]] = []
+    with Path(query_file).open("r", encoding="utf-8") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.rstrip("\n")
+            if not line.strip():
+                continue
+            if "\t" in line:
+                query_id, query_text = line.split("\t", 1)
+            else:
+                query_id = str(line_number)
+                query_text = line
+            query_text = query_text.strip()
+            if not query_text:
+                continue
+            loaded_queries.append((query_id.strip() or str(line_number), query_text))
+    if not loaded_queries:
+        raise RuntimeError(f"No non-empty queries found in {query_file}.")
+    return loaded_queries
+
+
+def _render_search_results(
+    *,
+    query_id: str,
+    query_text: str,
+    matches: Sequence[object],
+) -> list[str]:
+    if not matches:
+        return [f"{query_id}\t{query_text}\t0\t\t\t"]
+    rendered_rows: list[str] = []
+    for rank, match in enumerate(matches, start=1):
+        rendered_rows.append(
+            f"{query_id}\t{query_text}\t{rank}\t{match.concept_id}\t{match.similarity:.6f}\t{match.concept_name}"
+        )
+    return rendered_rows
+
+
+def _warm_search_backend(
+    *,
+    interface: EmbeddingInterface,
+    session: Session,
+    model_name: str,
+    metric_type: MetricType,
+) -> None:
+    backend = interface.backend
+    if backend.backend_type != BackendType.FAISS:
+        return
+    model_record = backend.get_registered_model(session=session, model_name=model_name)
+    if model_record is None:
+        raise RuntimeError(f"Embedding model '{model_name}' is not registered.")
+    storage_manager = backend.get_storage_manager(
+        model_name=model_name,
+        dimensions=model_record.dimensions,
+        index_type=model_record.index_type,
+        metadata=model_record.metadata,
+    )
+    started_at = time.monotonic()
+    storage_manager.get_index_manager(
+        index_type=model_record.index_type,
+        metric_type=metric_type,
+    )
+    _log_timing(
+        f"warm faiss index model={model_name} metric={metric_type.value}",
+        started_at,
+    )
+
+
+def _run_search_query(
+    *,
+    interface: EmbeddingInterface,
+    session: Session,
+    model_name: str,
+    query_texts: Sequence[str],
+    batch_size: int,
+    metric_type: MetricType,
+    concept_filter: Optional[EmbeddingConceptFilter],
+    k: int,
+) -> tuple[tuple[object, ...], ...]:
+    total_started_at = time.monotonic()
+    embed_started_at = time.monotonic()
+    query_embeddings = interface.embed_texts(list(query_texts), batch_size=batch_size)
+    _log_timing("embed query text", embed_started_at)
+
+    search_started_at = time.monotonic()
+    matches = interface.backend.get_nearest_concepts(
+        session=session,
+        model_name=model_name,
+        query_embeddings=query_embeddings,
+        metric_type=metric_type,
+        concept_filter=concept_filter,
+        k=k,
+    )
+    _log_timing("nearest-concept lookup", search_started_at)
+    _log_timing("full search request", total_started_at)
+    return matches
+
+
+def _search_response_payload(
+    *,
+    query_id: str,
+    query_text: str,
+    matches: Sequence[object],
+) -> dict[str, object]:
+    return {
+        "query_id": query_id,
+        "query_text": query_text,
+        "matches": [
+            {
+                "rank": rank,
+                "concept_id": int(match.concept_id),
+                "similarity": float(match.similarity),
+                "concept_name": match.concept_name,
+            }
+            for rank, match in enumerate(matches, start=1)
+        ],
+    }
 
 
 @app.command()
@@ -435,11 +563,12 @@ def search(
     interface.initialise_store(engine)
 
     with Session(engine) as session:
-        query_embeddings = interface.embed_texts(query_text, batch_size=batch_size)
-        matches = interface.backend.get_nearest_concepts(
+        matches = _run_search_query(
+            interface=interface,
             session=session,
             model_name=resolved_model,
-            query_embeddings=query_embeddings,
+            query_texts=(query_text,),
+            batch_size=batch_size,
             metric_type=metric_type,
             concept_filter=concept_filter,
             k=k,
@@ -454,6 +583,280 @@ def search(
         typer.echo(
             f"{rank}\t{match.concept_id}\t{match.similarity:.6f}\t{match.concept_name}"
         )
+
+
+@app.command("search-batch")
+def search_batch(
+    query_file: Annotated[str, typer.Argument(
+        help="Path to a UTF-8 text file containing one query per line, or `query_id<TAB>query_text` per line."
+    )],
+    api_base: Annotated[str, typer.Option(
+        "--api-base",
+        help="Base URL for the API to use for generating query embeddings.",
+    )],
+    api_key: Annotated[Optional[str], typer.Option(
+        "--api-key",
+        help="Optional API key for the embedding API. Can also be set with `OMOP_EMB_API_KEY`."
+    )] = None,
+    batch_size: Annotated[int, typer.Option(
+        "--batch-size", "-b",
+        help="Batch size to use when generating query embeddings and executing batched search."
+    )] = 32,
+    model: Annotated[Optional[str], typer.Option(
+        "--model", "-m",
+        help="Name of the embedding model to query."
+    )] = None,
+    embedding_path: Annotated[str, typer.Option(
+        "--embedding-path",
+        help="Embedding endpoint path relative to `--api-base`, for example `/embeddings` or `/embed`."
+    )] = "/embeddings",
+    backend_name: Annotated[Optional[str], typer.Option(
+        "--backend",
+        help="Embedding backend to query. Can be replaced by the `OMOP_EMB_BACKEND` environment variable."
+    )] = None,
+    faiss_base_dir: Annotated[Optional[str], typer.Option(
+        "--faiss-base-dir",
+        help="Optional base directory for FAISS backend storage."
+    )] = None,
+    metric_type: Annotated[MetricType, typer.Option(
+        "--metric-type",
+        help="Similarity or distance metric to use for nearest-neighbor search."
+    )] = MetricType.COSINE,
+    k: Annotated[int, typer.Option(
+        "--k",
+        help="Number of nearest concepts to return."
+    )] = 10,
+    standard_only: Annotated[bool, typer.Option(
+        "--standard-only",
+        help="If set, only search within OMOP standard concepts."
+    )] = False,
+    vocabularies: Annotated[Optional[list[str]], typer.Option(
+        "--vocabulary",
+        help="Optional vocabulary filter. Repeat to restrict the search space."
+    )] = None,
+    warm_index: Annotated[bool, typer.Option(
+        "--warm-index/--no-warm-index",
+        help="Preload the FAISS index once before processing the batch."
+    )] = True,
+):
+    configure_logging()
+    load_dotenv()
+
+    queries = _load_batch_queries(query_file)
+    engine = _create_engine_from_env()
+    logger.info("Embedding metadata schema: %s", get_metadata_schema())
+    interface, resolved_model = _create_embedding_interface(
+        api_base=api_base,
+        api_key=api_key,
+        batch_size=batch_size,
+        model=model,
+        backend_name=backend_name,
+        faiss_base_dir=faiss_base_dir,
+        embedding_path=embedding_path,
+    )
+    concept_filter = _build_concept_filter(
+        standard_only=standard_only,
+        vocabularies=vocabularies,
+    )
+    interface.initialise_store(engine)
+
+    typer.echo("query_id\tquery_text\trank\tconcept_id\tsimilarity\tconcept_name")
+    with Session(engine) as session:
+        if warm_index:
+            _warm_search_backend(
+                interface=interface,
+                session=session,
+                model_name=resolved_model,
+                metric_type=metric_type,
+            )
+
+        for batch_start in range(0, len(queries), batch_size):
+            query_batch = queries[batch_start:batch_start + batch_size]
+            matches_batch = _run_search_query(
+                interface=interface,
+                session=session,
+                model_name=resolved_model,
+                query_texts=[query_text for _, query_text in query_batch],
+                batch_size=batch_size,
+                metric_type=metric_type,
+                concept_filter=concept_filter,
+                k=k,
+            )
+            for (query_id, query_text), matches_per_query in zip(query_batch, matches_batch):
+                for row in _render_search_results(
+                    query_id=query_id,
+                    query_text=query_text,
+                    matches=matches_per_query,
+                ):
+                    typer.echo(row)
+
+
+@app.command("serve-search")
+def serve_search(
+    api_base: Annotated[str, typer.Option(
+        "--api-base",
+        help="Base URL for the API to use for generating query embeddings.",
+    )],
+    api_key: Annotated[Optional[str], typer.Option(
+        "--api-key",
+        help="Optional API key for the embedding API. Can also be set with `OMOP_EMB_API_KEY`."
+    )] = None,
+    batch_size: Annotated[int, typer.Option(
+        "--batch-size", "-b",
+        help="Batch size to use when generating query embeddings."
+    )] = 32,
+    model: Annotated[Optional[str], typer.Option(
+        "--model", "-m",
+        help="Name of the embedding model to query."
+    )] = None,
+    embedding_path: Annotated[str, typer.Option(
+        "--embedding-path",
+        help="Embedding endpoint path relative to `--api-base`, for example `/embeddings` or `/embed`."
+    )] = "/embeddings",
+    backend_name: Annotated[Optional[str], typer.Option(
+        "--backend",
+        help="Embedding backend to query. Can be replaced by the `OMOP_EMB_BACKEND` environment variable."
+    )] = None,
+    faiss_base_dir: Annotated[Optional[str], typer.Option(
+        "--faiss-base-dir",
+        help="Optional base directory for FAISS backend storage."
+    )] = None,
+    metric_type: Annotated[MetricType, typer.Option(
+        "--metric-type",
+        help="Similarity or distance metric to use for nearest-neighbor search."
+    )] = MetricType.COSINE,
+    k: Annotated[int, typer.Option(
+        "--k",
+        help="Number of nearest concepts to return."
+    )] = 10,
+    standard_only: Annotated[bool, typer.Option(
+        "--standard-only",
+        help="If set, only search within OMOP standard concepts."
+    )] = False,
+    vocabularies: Annotated[Optional[list[str]], typer.Option(
+        "--vocabulary",
+        help="Optional vocabulary filter. Repeat to restrict the search space."
+    )] = None,
+    host: Annotated[str, typer.Option(
+        "--host",
+        help="Host interface for the search service."
+    )] = "127.0.0.1",
+    port: Annotated[int, typer.Option(
+        "--port",
+        help="Port for the search service."
+    )] = 8080,
+    warm_index: Annotated[bool, typer.Option(
+        "--warm-index/--no-warm-index",
+        help="Preload the FAISS index before accepting requests."
+    )] = True,
+):
+    configure_logging()
+    load_dotenv()
+
+    engine = _create_engine_from_env()
+    logger.info("Embedding metadata schema: %s", get_metadata_schema())
+    interface, resolved_model = _create_embedding_interface(
+        api_base=api_base,
+        api_key=api_key,
+        batch_size=batch_size,
+        model=model,
+        backend_name=backend_name,
+        faiss_base_dir=faiss_base_dir,
+        embedding_path=embedding_path,
+    )
+    concept_filter = _build_concept_filter(
+        standard_only=standard_only,
+        vocabularies=vocabularies,
+    )
+    interface.initialise_store(engine)
+
+    if warm_index:
+        with Session(engine) as warm_session:
+            _warm_search_backend(
+                interface=interface,
+                session=warm_session,
+                model_name=resolved_model,
+                metric_type=metric_type,
+            )
+
+    class SearchHandler(BaseHTTPRequestHandler):
+        def _send_json(self, status_code: int, payload: dict[str, object]) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status_code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self) -> None:  # noqa: N802
+            if self.path == "/health":
+                self._send_json(
+                    200,
+                    {
+                        "status": "ok",
+                        "model": resolved_model,
+                        "backend": interface.backend.backend_name,
+                        "metric_type": metric_type.value,
+                    },
+                )
+                return
+            self._send_json(404, {"error": "not found"})
+
+        def do_POST(self) -> None:  # noqa: N802
+            if self.path != "/search":
+                self._send_json(404, {"error": "not found"})
+                return
+            content_length = int(self.headers.get("Content-Length", "0"))
+            raw_body = self.rfile.read(content_length)
+            try:
+                payload = json.loads(raw_body or b"{}")
+            except json.JSONDecodeError:
+                self._send_json(400, {"error": "invalid json"})
+                return
+
+            query_text = payload.get("query_text")
+            if not isinstance(query_text, str) or not query_text.strip():
+                self._send_json(400, {"error": "`query_text` must be a non-empty string"})
+                return
+
+            request_k = payload.get("k", k)
+            if not isinstance(request_k, int) or request_k <= 0:
+                self._send_json(400, {"error": "`k` must be a positive integer"})
+                return
+
+            with Session(engine) as session:
+                matches = _run_search_query(
+                    interface=interface,
+                    session=session,
+                    model_name=resolved_model,
+                    query_texts=(query_text,),
+                    batch_size=batch_size,
+                    metric_type=metric_type,
+                    concept_filter=concept_filter,
+                    k=request_k,
+                )
+            self._send_json(
+                200,
+                _search_response_payload(
+                    query_id=str(payload.get("query_id", "1")),
+                    query_text=query_text,
+                    matches=matches[0] if matches else (),
+                ),
+            )
+
+        def log_message(self, format: str, *args: object) -> None:
+            logger.info("search-service " + format, *args)
+
+    server = HTTPServer((host, port), SearchHandler)
+    typer.echo(
+        f"Serving search on http://{host}:{port} using model '{resolved_model}', backend '{interface.backend.backend_name}', metric '{metric_type.value}'."
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        logger.info("Stopping search service.")
+    finally:
+        server.server_close()
 
 
 @app.command("rebuild-index")

--- a/src/omop_emb/cli.py
+++ b/src/omop_emb/cli.py
@@ -3,7 +3,7 @@ from omop_llm import LLMClient
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
-from orm_loader.helpers import get_logger, configure_logging, create_db
+from orm_loader.helpers import get_logger, configure_logging
 
 from typing import Annotated, Optional
 import os
@@ -150,8 +150,7 @@ def add_embeddings(
         vocabularies=tuple(vocabularies) if vocabularies else None,
     )
     
-    # Ensure OMOP metadata tables exist, then initialize the embedding store.
-    create_db(engine)
+    # Initialize only the embedding store metadata for this project.
     interface.initialise_store(engine)
 
     with Session(engine) as reader, Session(engine) as writer:

--- a/src/omop_emb/cli.py
+++ b/src/omop_emb/cli.py
@@ -1,5 +1,3 @@
-from omop_llm import LLMClient
-
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
 
@@ -14,6 +12,7 @@ import typer
 from omop_emb.backends import (
     EmbeddingConceptFilter,
 )
+from omop_emb.embedding_client import OpenAICompatibleEmbeddingClient
 from omop_emb.interface import EmbeddingInterface
 from omop_emb.backends.config import IndexType
 
@@ -65,6 +64,28 @@ def _resolve_embedding_dim(
     return resolved_dim
 
 
+def _normalize_embedding_path(embedding_path: str) -> str:
+    normalized = embedding_path.strip()
+    if not normalized:
+        raise RuntimeError("Embedding path must not be empty.")
+    if not normalized.startswith("/"):
+        normalized = f"/{normalized}"
+    return normalized
+
+
+def _normalize_api_base(api_base: str, embedding_path: str) -> str:
+    normalized = api_base.rstrip("/")
+    normalized_path = _normalize_embedding_path(embedding_path)
+    if normalized.endswith(normalized_path):
+        normalized = normalized[: -len(normalized_path)]
+        logger.warning(
+            "API base ended with the embedding path `%s`. Normalizing to `%s` so the configured path is not duplicated.",
+            normalized_path,
+            normalized,
+        )
+    return normalized
+
+
 def _compile_sql(query: sa.Select, engine: sa.Engine) -> str:
     try:
         return str(
@@ -101,6 +122,10 @@ def add_embeddings(
         "--embedding-dim",
         help="Explicit embedding dimension for the configured model. Use this for OpenAI-compatible endpoints when the client cannot infer dimensions automatically. Can also be set with `OMOP_EMB_EMBEDDING_DIM`."
     )] = None,
+    embedding_path: Annotated[str, typer.Option(
+        "--embedding-path",
+        help="Embedding endpoint path relative to `--api-base`, for example `/embeddings` or `/embed`. Can also be set with `OMOP_EMB_EMBEDDING_PATH`."
+    )] = "/embeddings",
     backend_name: Annotated[Optional[str], typer.Option(
         "--backend",
         help="Embedding backend to use. Can be replaced by the `OMOP_EMB_BACKEND` environment variable."
@@ -129,6 +154,11 @@ def add_embeddings(
     if engine_string is None:
         raise RuntimeError("OMOP_DATABASE_URL environment variable not set. Please set it in your .env file to point to your database.")
     
+    resolved_embedding_path = _normalize_embedding_path(
+        os.getenv("OMOP_EMB_EMBEDDING_PATH") or embedding_path
+    )
+    resolved_api_base = _normalize_api_base(api_base, resolved_embedding_path)
+
     engine = sa.create_engine(engine_string, future=True, echo=False)
     assert engine.dialect.name == "postgresql", "Only PostgreSQL databases are supported for embedding storage with the current backends. Please check your `OMOP_DATABASE_URL` environment variable and ensure it points to a PostgreSQL database."
     resolved_model = _resolve_model_name(model)
@@ -136,11 +166,13 @@ def add_embeddings(
     interface = EmbeddingInterface.from_backend_name(
         backend_name=backend_name,
         faiss_base_dir=faiss_base_dir,
-        embedding_client=LLMClient(
+        embedding_client=OpenAICompatibleEmbeddingClient(
             model=resolved_model,
-            api_base=api_base,
+            api_base=resolved_api_base,
             api_key=api_key,
-            embedding_batch_size=batch_size
+            embedding_batch_size=batch_size,
+            embedding_path=resolved_embedding_path,
+            encoding_format="float",
         ),
     )
     resolved_embedding_dim = _resolve_embedding_dim(interface, embedding_dim)

--- a/src/omop_emb/cli.py
+++ b/src/omop_emb/cli.py
@@ -14,7 +14,14 @@ from omop_emb.backends import (
 )
 from omop_emb.embedding_client import OpenAICompatibleEmbeddingClient
 from omop_emb.interface import EmbeddingInterface
-from omop_emb.backends.config import IndexType, MetricType
+from omop_emb.backends.config import BackendType, IndexType, MetricType
+from omop_emb.backends.faiss.faiss_backend import (
+    DEFAULT_HNSW_EF_CONSTRUCTION,
+    DEFAULT_HNSW_EF_SEARCH,
+    DEFAULT_HNSW_NUM_NEIGHBORS,
+    FaissEmbeddingBackend,
+    build_faiss_index_metadata,
+)
 from omop_emb.backends.registry import get_metadata_schema
 
 app = typer.Typer()
@@ -94,6 +101,40 @@ def _normalize_api_base(api_base: str, embedding_path: str) -> str:
             normalized,
         )
     return normalized
+
+
+def _build_concept_filter(
+    *,
+    standard_only: bool,
+    vocabularies: Optional[list[str]],
+) -> Optional[EmbeddingConceptFilter]:
+    resolved_vocabularies = tuple(vocabularies) if vocabularies else None
+    if not standard_only and resolved_vocabularies is None:
+        return None
+    return EmbeddingConceptFilter(
+        require_standard=standard_only,
+        vocabularies=resolved_vocabularies,
+    )
+
+
+def _build_backend_metadata(
+    *,
+    backend_type: BackendType,
+    index_type: IndexType,
+    existing_metadata: Optional[dict[str, object]] = None,
+    hnsw_num_neighbors: Optional[int] = None,
+    hnsw_ef_search: Optional[int] = None,
+    hnsw_ef_construction: Optional[int] = None,
+) -> dict[str, object]:
+    if backend_type != BackendType.FAISS:
+        return dict(existing_metadata or {})
+    return build_faiss_index_metadata(
+        index_type=index_type,
+        existing_metadata=existing_metadata,
+        hnsw_num_neighbors=hnsw_num_neighbors,
+        hnsw_ef_search=hnsw_ef_search,
+        hnsw_ef_construction=hnsw_ef_construction,
+    )
 
 
 def _compile_sql(query: sa.Select, engine: sa.Engine) -> str:
@@ -192,6 +233,18 @@ def add_embeddings(
         "--faiss-base-dir",
         help="Optional base directory for FAISS backend storage."
     )] = None,
+    hnsw_num_neighbors: Annotated[int, typer.Option(
+        "--hnsw-num-neighbors",
+        help="FAISS HNSW M parameter. Used when `--index-type hnsw`."
+    )] = DEFAULT_HNSW_NUM_NEIGHBORS,
+    hnsw_ef_search: Annotated[int, typer.Option(
+        "--hnsw-ef-search",
+        help="FAISS HNSW efSearch parameter. Used when `--index-type hnsw`."
+    )] = DEFAULT_HNSW_EF_SEARCH,
+    hnsw_ef_construction: Annotated[int, typer.Option(
+        "--hnsw-ef-construction",
+        help="FAISS HNSW efConstruction parameter. Used when `--index-type hnsw`."
+    )] = DEFAULT_HNSW_EF_CONSTRUCTION,
     standard_only: Annotated[bool, typer.Option(
         "--standard-only",
         help="If set, only generate embeddings for OMOP standard concepts (standard_concept = 'S')."
@@ -218,10 +271,17 @@ def add_embeddings(
         embedding_path=embedding_path,
     )
     resolved_embedding_dim = _resolve_embedding_dim(interface, embedding_dim)
+    backend_metadata = _build_backend_metadata(
+        backend_type=interface.backend.backend_type,
+        index_type=index_type,
+        hnsw_num_neighbors=hnsw_num_neighbors,
+        hnsw_ef_search=hnsw_ef_search,
+        hnsw_ef_construction=hnsw_ef_construction,
+    )
 
-    concept_filter = EmbeddingConceptFilter(
-        require_standard=standard_only,
-        vocabularies=tuple(vocabularies) if vocabularies else None,
+    concept_filter = _build_concept_filter(
+        standard_only=standard_only,
+        vocabularies=vocabularies,
     )
     
     # Initialize only the embedding store metadata for this project.
@@ -234,6 +294,7 @@ def add_embeddings(
             model_name=resolved_model,
             index_type=index_type,
             dimensions=resolved_embedding_dim,
+            metadata=backend_metadata,
             overwrite_existing_conflicts=overwrite_model_registration,
         )
 
@@ -294,6 +355,12 @@ def add_embeddings(
                 pbar.update(len(batch_concepts))
 
     logger.info("Completed embedding generation and storage. Wrote %s embeddings.", processed_concepts)
+    if interface.backend.backend_type == BackendType.FAISS:
+        typer.echo(
+            "FAISS note: raw embeddings were written to HDF5 storage. "
+            "Rebuild the metric-specific FAISS index before search, for example: "
+            f"omop-emb rebuild-index --model {resolved_model} --backend faiss --metric-type cosine"
+        )
 
 
 @app.command()
@@ -360,9 +427,9 @@ def search(
         faiss_base_dir=faiss_base_dir,
         embedding_path=embedding_path,
     )
-    concept_filter = EmbeddingConceptFilter(
-        require_standard=standard_only,
-        vocabularies=tuple(vocabularies) if vocabularies else None,
+    concept_filter = _build_concept_filter(
+        standard_only=standard_only,
+        vocabularies=vocabularies,
     )
 
     interface.initialise_store(engine)
@@ -433,6 +500,97 @@ def rebuild_index(
         )
 
     logger.info("Completed index rebuild for model '%s'.", resolved_model)
+
+
+@app.command("switch-index-type")
+def switch_index_type(
+    model: Annotated[Optional[str], typer.Option(
+        "--model", "-m",
+        help="Registered embedding model name to update."
+    )] = None,
+    backend_name: Annotated[Optional[str], typer.Option(
+        "--backend",
+        help="Embedding backend to update. Currently only FAISS supports index switching."
+    )] = None,
+    faiss_base_dir: Annotated[Optional[str], typer.Option(
+        "--faiss-base-dir",
+        help="Optional base directory for FAISS backend storage."
+    )] = None,
+    index_type: Annotated[IndexType, typer.Option(
+        "--index-type",
+        help="New FAISS index type to store in the model registry."
+    )] = IndexType.HNSW,
+    metric_types: Annotated[Optional[list[MetricType]], typer.Option(
+        "--metric-type",
+        help="Metric(s) to rebuild after switching. Defaults to all metrics supported by the new index type."
+    )] = None,
+    hnsw_num_neighbors: Annotated[int, typer.Option(
+        "--hnsw-num-neighbors",
+        help="FAISS HNSW M parameter. Used when `--index-type hnsw`."
+    )] = DEFAULT_HNSW_NUM_NEIGHBORS,
+    hnsw_ef_search: Annotated[int, typer.Option(
+        "--hnsw-ef-search",
+        help="FAISS HNSW efSearch parameter. Used when `--index-type hnsw`."
+    )] = DEFAULT_HNSW_EF_SEARCH,
+    hnsw_ef_construction: Annotated[int, typer.Option(
+        "--hnsw-ef-construction",
+        help="FAISS HNSW efConstruction parameter. Used when `--index-type hnsw`."
+    )] = DEFAULT_HNSW_EF_CONSTRUCTION,
+    batch_size: Annotated[int, typer.Option(
+        "--batch-size", "-b",
+        help="Batch size to use when streaming embeddings from disk during rebuild."
+    )] = 100_000,
+    rebuild: Annotated[bool, typer.Option(
+        "--rebuild/--no-rebuild",
+        help="If set, rebuild FAISS index files immediately after updating the registry."
+    )] = True,
+):
+    configure_logging()
+    load_dotenv()
+
+    engine = _create_engine_from_env()
+    logger.info("Embedding metadata schema: %s", get_metadata_schema())
+    interface = EmbeddingInterface.from_backend_name(
+        backend_name=backend_name,
+        faiss_base_dir=faiss_base_dir,
+    )
+    resolved_model = _resolve_model_name(model)
+    interface.initialise_store(engine)
+
+    if interface.backend.backend_type != BackendType.FAISS or not isinstance(interface.backend, FaissEmbeddingBackend):
+        raise RuntimeError("Index-type switching is currently only supported for the FAISS backend.")
+
+    with Session(engine) as session:
+        existing_model = interface.backend.get_registered_model(session=session, model_name=resolved_model)
+        if existing_model is None:
+            raise RuntimeError(f"Embedding model '{resolved_model}' is not registered.")
+
+        metadata = _build_backend_metadata(
+            backend_type=interface.backend.backend_type,
+            index_type=index_type,
+            existing_metadata=dict(existing_model.metadata),
+            hnsw_num_neighbors=hnsw_num_neighbors,
+            hnsw_ef_search=hnsw_ef_search,
+            hnsw_ef_construction=hnsw_ef_construction,
+        )
+        interface.backend.update_model_index_configuration(
+            session=session,
+            model_name=resolved_model,
+            index_type=index_type,
+            metadata=metadata,
+        )
+        if rebuild:
+            interface.rebuild_model_indexes(
+                session=session,
+                model_name=resolved_model,
+                metric_types=tuple(metric_types) if metric_types else None,
+                batch_size=batch_size,
+            )
+
+    typer.echo(
+        f"Updated model '{resolved_model}' to index_type={index_type.value}."
+        + (" Rebuilt FAISS index files." if rebuild else "")
+    )
 
 
 if __name__ == "__main__":

--- a/src/omop_emb/cli.py
+++ b/src/omop_emb/cli.py
@@ -65,6 +65,18 @@ def _resolve_embedding_dim(
     return resolved_dim
 
 
+def _compile_sql(query: sa.Select, engine: sa.Engine) -> str:
+    try:
+        return str(
+            query.compile(
+                dialect=engine.dialect,
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+    except Exception:
+        return str(query)
+
+
 @app.command()
 def add_embeddings(
     api_base: Annotated[str, typer.Option(
@@ -151,7 +163,7 @@ def add_embeddings(
             dimensions=resolved_embedding_dim
         )
 
-        total_concepts = num_embeddings or interface.get_concepts_without_embedding_count(
+        estimated_total_concepts = num_embeddings or interface.get_concepts_without_embedding_count(
             session=reader,
             model_name=resolved_model,
             concept_filter=concept_filter,
@@ -162,13 +174,39 @@ def add_embeddings(
             concept_filter=concept_filter,
             limit=num_embeddings,
         )
+        actual_total_concepts = reader.scalar(
+            sa.select(sa.func.count()).select_from(concepts_without_embedding.subquery())
+        )
 
-        logger.info(f"Total concepts to process: {total_concepts}")
-        with tqdm(total=total_concepts, desc="Processing", unit="concept") as pbar:
+        logger.info(
+            "Embedding source query: %s",
+            _compile_sql(concepts_without_embedding, engine),
+        )
+        if num_embeddings is not None:
+            logger.info(
+                "Requested up to %s concepts; query returned %s concepts.",
+                num_embeddings,
+                actual_total_concepts,
+            )
+        else:
+            logger.info("Query returned %s concepts.", actual_total_concepts)
+
+        logger.info(
+            "Progress bar total: %s concepts.",
+            actual_total_concepts if num_embeddings is not None else estimated_total_concepts,
+        )
+        processed_concepts = 0
+        with tqdm(
+            total=actual_total_concepts if num_embeddings is not None else estimated_total_concepts,
+            desc="Processing",
+            unit="concept",
+        ) as pbar:
             result = reader.execute(concepts_without_embedding)
             
             for row_chunk in result.partitions(batch_size):
                 batch_concepts = {row.concept_id: row.concept_name for row in row_chunk}
+                if not batch_concepts:
+                    continue
                 
                 interface.embed_and_upsert_concepts(
                     session=writer,
@@ -178,9 +216,10 @@ def add_embeddings(
                     batch_size=batch_size,
                 )
                 
+                processed_concepts += len(batch_concepts)
                 pbar.update(len(batch_concepts))
 
-    logger.info("Completed embedding generation and storage.")
+    logger.info("Completed embedding generation and storage. Wrote %s embeddings.", processed_concepts)
 
 
 if __name__ == "__main__":

--- a/src/omop_emb/cli.py
+++ b/src/omop_emb/cli.py
@@ -29,6 +29,15 @@ def _resolve_model_name(model: Optional[str]) -> str:
     return resolved_model
 
 
+def _resolve_api_key(api_key: Optional[str]) -> Optional[str]:
+    resolved_api_key = api_key
+    if resolved_api_key is None:
+        resolved_api_key = os.getenv("OMOP_EMB_API_KEY")
+    if resolved_api_key == "":
+        return None
+    return resolved_api_key
+
+
 def _resolve_embedding_dim(
     interface: EmbeddingInterface,
     embedding_dim: Optional[int],
@@ -104,9 +113,10 @@ def add_embeddings(
         "--api-base",
         help="Base URL for the API to use for generating embeddings.",
     )],
-    api_key: Annotated[str, typer.Option(
+    api_key: Annotated[Optional[str], typer.Option(
         "--api-key",
-        help="API key for the embedding API.")],
+        help="Optional API key for the embedding API. Can also be set with `OMOP_EMB_API_KEY`."
+    )] = None,
     index_type: Annotated[IndexType, typer.Option(
         "--index-type",
         help="Backend-specific index type for newly registered models and how it should be stored.",
@@ -158,6 +168,7 @@ def add_embeddings(
         os.getenv("OMOP_EMB_EMBEDDING_PATH") or embedding_path
     )
     resolved_api_base = _normalize_api_base(api_base, resolved_embedding_path)
+    resolved_api_key = _resolve_api_key(api_key)
 
     engine = sa.create_engine(engine_string, future=True, echo=False)
     assert engine.dialect.name == "postgresql", "Only PostgreSQL databases are supported for embedding storage with the current backends. Please check your `OMOP_DATABASE_URL` environment variable and ensure it points to a PostgreSQL database."
@@ -169,7 +180,7 @@ def add_embeddings(
         embedding_client=OpenAICompatibleEmbeddingClient(
             model=resolved_model,
             api_base=resolved_api_base,
-            api_key=api_key,
+            api_key=resolved_api_key,
             embedding_batch_size=batch_size,
             embedding_path=resolved_embedding_path,
             encoding_format="float",

--- a/src/omop_emb/embedding_client.py
+++ b/src/omop_emb/embedding_client.py
@@ -27,7 +27,7 @@ class EmbeddingClientProtocol(Protocol):
 class OpenAICompatibleEmbeddingClient:
     model: str
     api_base: str
-    api_key: str
+    api_key: Optional[str] = None
     embedding_batch_size: int = 32
     embedding_path: str = "/embeddings"
     encoding_format: str = "float"
@@ -84,8 +84,9 @@ class OpenAICompatibleEmbeddingClient:
 
         headers = {
             "Content-Type": "application/json",
-            "Authorization": f"Bearer {self.api_key}",
         }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
         batch_buffer: list[list[float]] = []
 
         for batch_chunk_idx in range(0, len(text), batch_size):

--- a/src/omop_emb/embedding_client.py
+++ b/src/omop_emb/embedding_client.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+from typing import List, Optional, Protocol, Sequence, Tuple, Union
+
+import numpy as np
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingClientProtocol(Protocol):
+    @property
+    def embedding_dim(self) -> Optional[int]:
+        ...
+
+    def embeddings(
+        self,
+        text: Union[str, List[str], Tuple[str, ...]],
+        batch_size: Optional[int] = None,
+    ) -> np.ndarray:
+        ...
+
+
+@dataclass
+class OpenAICompatibleEmbeddingClient:
+    model: str
+    api_base: str
+    api_key: str
+    embedding_batch_size: int = 32
+    embedding_path: str = "/embeddings"
+    encoding_format: str = "float"
+    request_timeout: float = 120.0
+    _embedding_dim: Optional[int] = field(default=None, init=False, repr=False)
+
+    @property
+    def endpoint_url(self) -> str:
+        return f"{self.api_base.rstrip('/')}/{self.embedding_path.lstrip('/')}"
+
+    @property
+    def embedding_dim(self) -> Optional[int]:
+        if self._embedding_dim is not None:
+            return self._embedding_dim
+
+        if (
+            "ollama" in self.api_base
+            or (
+                ("localhost" in self.api_base or "127.0.0.1" in self.api_base)
+                and self.api_key == "ollama"
+            )
+        ):
+            ollama_url_without_v1 = self.api_base.replace("/v1", "")
+            response = requests.post(
+                f"{ollama_url_without_v1}/api/show",
+                json={"name": self.model},
+                timeout=self.request_timeout,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            model_info = payload.get("model_info", {})
+
+            embedding_key = [key for key in model_info.keys() if "embedding_length" in key]
+            if len(embedding_key) == 1:
+                self._embedding_dim = int(model_info[embedding_key[0]])
+                return self._embedding_dim
+
+            raise ValueError(f"Model information not found in Ollama response: {payload}")
+
+        raise NotImplementedError("Embedding dimension retrieval not implemented for this API base")
+
+    def embeddings(
+        self,
+        text: Union[str, List[str], Tuple[str, ...]],
+        batch_size: Optional[int] = None,
+    ) -> np.ndarray:
+        if batch_size is None:
+            batch_size = self.embedding_batch_size
+
+        if isinstance(text, str):
+            text = (text,)
+        elif isinstance(text, list):
+            text = tuple(text)
+
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+        }
+        batch_buffer: list[list[float]] = []
+
+        for batch_chunk_idx in range(0, len(text), batch_size):
+            batch_chunk = list(text[batch_chunk_idx:batch_chunk_idx + batch_size])
+            payload = {
+                "model": self.model,
+                "input": batch_chunk,
+                "encoding_format": self.encoding_format,
+            }
+            response = requests.post(
+                self.endpoint_url,
+                json=payload,
+                headers=headers,
+                timeout=self.request_timeout,
+            )
+            try:
+                response.raise_for_status()
+            except requests.HTTPError as exc:
+                detail = response.text.strip()
+                raise RuntimeError(
+                    f"Embedding request failed with status {response.status_code} at "
+                    f"{self.endpoint_url}: {detail}"
+                ) from exc
+
+            batch_buffer.extend(self._parse_embeddings_response(response.json()))
+
+        return np.array(batch_buffer, dtype=np.float32)
+
+    @staticmethod
+    def _parse_embeddings_response(payload: object) -> list[list[float]]:
+        if isinstance(payload, dict):
+            data = payload.get("data")
+            if isinstance(data, list):
+                return [item["embedding"] for item in data]
+
+            embeddings = payload.get("embeddings")
+            if isinstance(embeddings, list):
+                if embeddings and isinstance(embeddings[0], dict):
+                    return [item["embedding"] for item in embeddings]
+                return embeddings
+
+            embedding = payload.get("embedding")
+            if isinstance(embedding, list):
+                return [embedding]
+
+        raise ValueError(f"Unexpected embeddings response payload: {payload}")

--- a/src/omop_emb/interface.py
+++ b/src/omop_emb/interface.py
@@ -8,8 +8,6 @@ from numpy import ndarray
 from sqlalchemy import Engine, Select
 from sqlalchemy.orm import Session
 
-from omop_llm import LLMClient
-
 from .backends import (
     EmbeddingBackend,
     EmbeddingConceptFilter,
@@ -17,6 +15,7 @@ from .backends import (
     get_embedding_backend,
 )
 from .backends.config import IndexType, MetricType
+from .embedding_client import EmbeddingClientProtocol
 
 
 @dataclass
@@ -28,12 +27,12 @@ class EmbeddingInterface:
     ----------------
     - initialize the selected backend store
     - ensure an embedding model is registered
-    - generate embeddings with an ``LLMClient``
+    - generate embeddings with an embedding client
     - upsert concept embeddings through the selected backend
     - provide a reusable in-process cache for query-text embeddings
 
     """
-    embedding_client: Optional[LLMClient] = None
+    embedding_client: Optional[EmbeddingClientProtocol] = None
     backend: EmbeddingBackend = field(default_factory=get_embedding_backend)
 
 
@@ -46,7 +45,7 @@ class EmbeddingInterface:
     @classmethod
     def from_backend_name(
         cls,
-        embedding_client: Optional[LLMClient] = None,
+        embedding_client: Optional[EmbeddingClientProtocol] = None,
         backend_name: Optional[str] = None,
         *,
         faiss_base_dir: Optional[str] = None,
@@ -271,7 +270,7 @@ class EmbeddingInterface:
         self,
         texts: str | Tuple[str, ...] | List[str],
         *,
-        embedding_client: Optional[LLMClient] = None,
+        embedding_client: Optional[EmbeddingClientProtocol] = None,
         batch_size: Optional[int] = None,
     ) -> np.ndarray:
         client = embedding_client or self.embedding_client
@@ -301,7 +300,7 @@ class EmbeddingInterface:
         model_name: str,
         concept_ids: Sequence[int],
         concept_texts: Sequence[str],
-        embedding_client: Optional[LLMClient] = None,
+        embedding_client: Optional[EmbeddingClientProtocol] = None,
         batch_size: Optional[int] = None,
     ) -> ndarray:
         if len(concept_ids) != len(concept_texts):

--- a/src/omop_emb/interface.py
+++ b/src/omop_emb/interface.py
@@ -253,10 +253,30 @@ class EmbeddingInterface:
         Ensure the embedding model exists in the selected backend.
         """
 
+        if overwrite_existing_conflicts:
+            self.backend.delete_model(
+                engine=engine,
+                session=session,
+                model_name=model_name,
+            )
+            return self.backend.register_model(
+                engine=engine,
+                model_name=model_name,
+                dimensions=dimensions,
+                index_type=index_type,
+                metadata=metadata,
+            )
+
         existing = self.backend.get_registered_model(
             session=session,
             model_name=model_name,
         )
+        if existing is None and self.backend.has_stale_model_artifacts(model_name):
+            raise RuntimeError(
+                f"Backend artifacts already exist for model '{model_name}' but no matching "
+                "SQL registration was found. Re-run with "
+                "`--overwrite-model-registration` to force a clean rebuild."
+            )
         if existing is not None:
             conflict: Optional[ModelRegistrationConflictError] = None
             if existing.dimensions != dimensions:
@@ -285,14 +305,6 @@ class EmbeddingInterface:
                 return existing
             if not overwrite_existing_conflicts:
                 raise conflict
-
-            self.backend.delete_model(
-                engine=engine,
-                session=session,
-                model_name=model_name,
-            )
-        else:
-            pass
 
         return self.backend.register_model(
             engine=engine,

--- a/src/omop_emb/interface.py
+++ b/src/omop_emb/interface.py
@@ -218,6 +218,26 @@ class EmbeddingInterface:
 
         return self.backend.initialise_store(engine)
 
+    def rebuild_model_indexes(
+        self,
+        *,
+        session: Session,
+        model_name: str,
+        metric_types: Optional[Sequence[MetricType]] = None,
+        batch_size: int = 100_000,
+    ) -> None:
+        rebuild = getattr(self.backend, "rebuild_model_indexes", None)
+        if rebuild is None:
+            raise NotImplementedError(
+                f"Backend {self.backend.backend_name!r} does not implement explicit index rebuilds."
+            )
+        rebuild(
+            session=session,
+            model_name=model_name,
+            metric_types=metric_types,
+            batch_size=batch_size,
+        )
+
     def add_to_db(
         self,
         session: Session,

--- a/src/omop_emb/interface.py
+++ b/src/omop_emb/interface.py
@@ -15,6 +15,7 @@ from .backends import (
     get_embedding_backend,
 )
 from .backends.config import IndexType, MetricType
+from .backends.errors import ModelRegistrationConflictError
 from .embedding_client import EmbeddingClientProtocol
 
 
@@ -246,6 +247,7 @@ class EmbeddingInterface:
         dimensions: int,
         index_type: IndexType,
         metadata: Mapping[str, object] = {},
+        overwrite_existing_conflicts: bool = False,
     ) -> EmbeddingModelRecord:
         """
         Ensure the embedding model exists in the selected backend.
@@ -256,15 +258,49 @@ class EmbeddingInterface:
             model_name=model_name,
         )
         if existing is not None:
-            return existing
-        else:
-            return self.backend.register_model(
+            conflict: Optional[ModelRegistrationConflictError] = None
+            if existing.dimensions != dimensions:
+                conflict = ModelRegistrationConflictError(
+                    f"Model '{model_name}' is already registered with dimensions "
+                    f"{existing.dimensions}, not {dimensions}. Reuse the existing "
+                    "configuration, choose a new model name, or delete the existing "
+                    "registration before rerunning.",
+                    conflict_field="dimensions",
+                )
+            elif existing.index_type != index_type:
+                conflict = ModelRegistrationConflictError(
+                    f"Model '{model_name}' is already registered with index_type "
+                    f"'{existing.index_type}', not '{index_type}'. Reuse the existing "
+                    "configuration or choose a new model name.",
+                    conflict_field="index_type",
+                )
+            elif existing.metadata != metadata:
+                conflict = ModelRegistrationConflictError(
+                    f"Model '{model_name}' is already registered with different "
+                    "metadata. Reuse the existing model name or choose a new one.",
+                    conflict_field="metadata",
+                )
+
+            if conflict is None:
+                return existing
+            if not overwrite_existing_conflicts:
+                raise conflict
+
+            self.backend.delete_model(
                 engine=engine,
+                session=session,
                 model_name=model_name,
-                dimensions=dimensions,
-                index_type=index_type,
-                metadata=metadata,
             )
+        else:
+            pass
+
+        return self.backend.register_model(
+            engine=engine,
+            model_name=model_name,
+            dimensions=dimensions,
+            index_type=index_type,
+            metadata=metadata,
+        )
 
     def embed_texts(
         self,

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ Minimal, focused test suite for omop-emb with FAISS backend testing.
 
 ### PostgreSQL Database
 
-Tests require a running PostgreSQL instance. By default, tests connect to:
+Integration tests require a running PostgreSQL instance. By default, tests connect to:
 - **Host**: localhost
 - **Port**: 5432
 - **Database**: omop_emb_test
@@ -25,15 +25,6 @@ docker run --name omop-emb-test-db \
   -e POSTGRES_PASSWORD=postgres \
   -p 5432:5432 \
   -d postgres:15
-```
-
-### Custom Connection String
-
-Override the connection string via environment variable:
-
-```bash
-export TEST_DATABASE_URL="postgresql+psycopg2://user:password@host:port/database"
-pytest tests/
 ```
 
 ### Existing Database Mode
@@ -86,6 +77,9 @@ pytest tests/ -m "pgvector and integration"
 pytest tests/ -m "unit and not pgvector"
 ```
 
+This is the recommended default for FAISS-only users who do not want to run the
+PostgreSQL integration suite.
+
 ### Specific test file
 ```bash
 pytest tests/test_interface.py -v
@@ -98,13 +92,19 @@ pip install -e ".[faiss]"
 pip install pytest
 ```
 
+If you want to run pgvector integration tests as well:
+
+```bash
+pip install -e ".[faiss,pgvector]"
+```
+
 ## Test Files
 
 - `conftest.py` - Fixtures and database setup
 - `test_fixtures.py` - PostgreSQL fixture validation tests
-- `test_interface.py` - EmbeddingInterface tests
-- `test_faiss.py` - FAISS backend tests
-- `test_pgvector.py` - pgvector backend tests
+- `test_interface.py` - Mixed unit and integration tests for `EmbeddingInterface`
+- `test_faiss.py` - FAISS backend integration tests
+- `test_pgvector.py` - pgvector backend integration tests
 - `test_config.py` - Configuration and factory tests
 
 ## Fixtures
@@ -119,7 +119,7 @@ pip install pytest
 ### Backend Fixtures
 - `temp_faiss_dir` - Temporary FAISS index directory
 - `faiss_backend` - Initialized FAISS backend
-- `embedding_interface` - Full EmbeddingInterface
+- `embedding_interface` - Initialized `EmbeddingInterface` backed by the FAISS fixture
 
 ### Test Data Helper
 - `add_concepts_to_db()` - Helper function to load test concepts
@@ -142,6 +142,11 @@ def test_something(session):
 
 - Backend and fixture integration tests require PostgreSQL
 - Pure unit tests can be run with `pytest tests/ -m unit`
+- `pytest -m "not pgvector"` still includes FAISS integration tests; use
+  `pytest -m unit` if you want to avoid all database-backed tests
 - Foreign key constraints are enforced (required data must be complete)
 - Each test gets a clean, isolated session
-- Concept table is truncated before each test
+- In integration tests, the harness truncates the test schema's `concept` and
+  `model_registry` tables before each test. In `TEST_DB_USE_EXISTING=1` mode,
+  this happens in `TEST_DB_SCHEMA`, not in your application schemas such as
+  `vocabulary` or `staging_vocabulary`

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,6 +36,24 @@ export TEST_DATABASE_URL="postgresql+psycopg2://user:password@host:port/database
 pytest tests/
 ```
 
+### Existing Database Mode
+
+If you do not want to provide admin credentials, run the PostgreSQL tests inside
+a dedicated schema of an existing database:
+
+```bash
+export TEST_DB_HOST=localhost
+export TEST_DB_PORT=5432
+export TEST_DATABASE_NAME=my_existing_database
+export TEST_DB_USERNAME=my_app_user
+export TEST_DB_PASSWORD=my_app_password
+export TEST_DB_USE_EXISTING=1
+export TEST_DB_SCHEMA=omop_emb_test
+```
+
+In this mode the harness does not create or drop databases or roles. It creates
+tables only inside `TEST_DB_SCHEMA` and sets `search_path` accordingly.
+
 ## Running Tests
 
 ### All tests
@@ -48,14 +66,24 @@ pytest tests/ -v
 pytest tests/ -m unit
 ```
 
-### FAISS backend tests
+### Integration tests only
 ```bash
-pytest tests/ -m faiss
+pytest tests/ -m integration
 ```
 
-### pgvector backend tests
+### FAISS backend integration tests
 ```bash
-pytest tests/ -m pgvector
+pytest tests/ -m "faiss and integration"
+```
+
+### pgvector backend integration tests
+```bash
+pytest tests/ -m "pgvector and integration"
+```
+
+### FAISS-only users
+```bash
+pytest tests/ -m "unit and not pgvector"
 ```
 
 ### Specific test file
@@ -73,7 +101,7 @@ pip install pytest
 ## Test Files
 
 - `conftest.py` - Fixtures and database setup
-- `test_fixtures.py` - Fixture validation tests
+- `test_fixtures.py` - PostgreSQL fixture validation tests
 - `test_interface.py` - EmbeddingInterface tests
 - `test_faiss.py` - FAISS backend tests
 - `test_pgvector.py` - pgvector backend tests
@@ -112,7 +140,8 @@ def test_something(session):
 
 ## Notes
 
-- Tests use PostgreSQL only (no SQLite)
+- Backend and fixture integration tests require PostgreSQL
+- Pure unit tests can be run with `pytest tests/ -m unit`
 - Foreign key constraints are enforced (required data must be complete)
 - Each test gets a clean, isolated session
 - Concept table is truncated before each test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import os
 import time
 import tempfile
 from pathlib import Path
-from typing import Generator, Dict, Any, Optional
+from typing import Generator, Dict, Any, Optional, TYPE_CHECKING
 from unittest.mock import Mock
 from dataclasses import dataclass, field
 
@@ -22,15 +22,27 @@ from orm_loader.helpers import Base
 from omop_llm import LLMClient
 
 from omop_emb.backends.faiss import FaissEmbeddingBackend
-from omop_emb.backends.pgvector import PGVectorEmbeddingBackend
 from omop_emb.backends.registry import ensure_model_registry_schema, ModelRegistry
 from omop_emb.interface import EmbeddingInterface
 from omop_emb.backends.config import IndexType
+
+if TYPE_CHECKING:
+    from omop_emb.backends.pgvector import PGVectorEmbeddingBackend
+
+try:
+    from omop_emb.backends.pgvector import PGVectorEmbeddingBackend
+    HAS_PGVECTOR = True
+except ImportError:
+    PGVectorEmbeddingBackend = None  # type: ignore[assignment]
+    HAS_PGVECTOR = False
 
 
 TEST_DB_NAME = os.getenv("TEST_DATABASE_NAME", "test_omop_emb")
 TEST_USERNAME = os.getenv("TEST_DB_USERNAME", "test")
 TEST_PASSWORD = os.getenv("TEST_DB_PASSWORD", "test")
+TEST_DB_USE_EXISTING = os.getenv("TEST_DB_USE_EXISTING", "").lower() in {"1", "true", "yes"}
+TEST_DB_SCHEMA = os.getenv("TEST_DB_SCHEMA", "test_omop_emb")
+TEST_DB_CLEANUP_SCHEMA_ON_EXIT = os.getenv("TEST_DB_CLEANUP_SCHEMA_ON_EXIT", "").lower() in {"1", "true", "yes"}
 
 DB_HOST = os.getenv("TEST_DB_HOST", None)
 DB_PORT = os.getenv("TEST_DB_PORT", None)
@@ -40,6 +52,16 @@ DB_ADMIN_PASS = os.getenv("POSTGRES_PASSWORD", "postgres")
 
 
 # ================ Fixtures ================
+
+
+def pytest_collection_modifyitems(config, items):
+    if HAS_PGVECTOR:
+        return
+
+    skip_pgvector = pytest.mark.skip(reason="pgvector dependency is not installed")
+    for item in items:
+        if "pgvector" in item.keywords:
+            item.add_marker(skip_pgvector)
 
 
 def _create_test_url() -> sa.URL:
@@ -59,6 +81,10 @@ def _create_test_url() -> sa.URL:
         port=int(DB_PORT),
         database=TEST_DB_NAME
     )
+
+
+def _engine_connect_args() -> dict[str, str]:
+    return {"options": f"-csearch_path={TEST_DB_SCHEMA}"}
 
 def _create_admin_url() -> sa.URL:
     """Construct the admin database URL for managing test DB."""
@@ -98,6 +124,16 @@ def _create_test_database() -> sa.URL:
     return test_url
 
 
+def _prepare_existing_test_schema(engine: sa.Engine) -> None:
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        conn.execute(sa.text(f'CREATE SCHEMA IF NOT EXISTS "{TEST_DB_SCHEMA}"'))
+
+
+def _drop_existing_test_schema(engine: sa.Engine) -> None:
+    with engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        conn.execute(sa.text(f'DROP SCHEMA IF EXISTS "{TEST_DB_SCHEMA}" CASCADE'))
+
+
 def _drop_test_database() -> None:
     """Drop the test database and the associated test user."""
     admin_url = _create_admin_url()
@@ -122,16 +158,31 @@ def _drop_test_database() -> None:
 
 @pytest.fixture(scope="session")
 def pg_engine():
-    """Create PostgreSQL engine with retry logic and dedicated test DB."""
-    test_db_url = _create_test_database()
+    """Create PostgreSQL engine with retry logic and dedicated DB or isolated schema."""
+    if TEST_DB_USE_EXISTING:
+        test_db_url = _create_test_url()
+    else:
+        test_db_url = _create_test_database()
 
     max_retries = 20
     for attempt in range(max_retries):
         try:
-            engine = sa.create_engine(test_db_url, echo=False, future=True)
+            engine = sa.create_engine(
+                test_db_url,
+                echo=False,
+                future=True,
+                connect_args=_engine_connect_args(),
+            )
             with engine.connect() as conn:
                 conn.execute(sa.text("SELECT 1"))
-            print(f"\n--- PostgreSQL connection established to {TEST_DB_NAME} ---")
+            if TEST_DB_USE_EXISTING:
+                _prepare_existing_test_schema(engine)
+                print(
+                    f"\n--- PostgreSQL connection established to existing database "
+                    f"{TEST_DB_NAME} using schema {TEST_DB_SCHEMA} ---"
+                )
+            else:
+                print(f"\n--- PostgreSQL connection established to {TEST_DB_NAME} ---")
             
             # Create all tables
             Base.metadata.create_all(engine)
@@ -140,7 +191,20 @@ def pg_engine():
             yield engine
             
             engine.dispose()
-            _drop_test_database()
+            if TEST_DB_USE_EXISTING:
+                if TEST_DB_CLEANUP_SCHEMA_ON_EXIT:
+                    cleanup_engine = sa.create_engine(
+                        test_db_url,
+                        echo=False,
+                        future=True,
+                        connect_args=_engine_connect_args(),
+                    )
+                    try:
+                        _drop_existing_test_schema(cleanup_engine)
+                    finally:
+                        cleanup_engine.dispose()
+            else:
+                _drop_test_database()
             return
 
         except Exception as e:
@@ -148,7 +212,8 @@ def pg_engine():
                 print(f"[{attempt + 1}/{max_retries}] PostgreSQL not ready: {e}")
                 time.sleep(1)
             else:
-                _drop_test_database()
+                if not TEST_DB_USE_EXISTING:
+                    _drop_test_database()
                 raise RuntimeError(f"PostgreSQL never became available after {max_retries} attempts: {e}")
 
 
@@ -209,8 +274,10 @@ def faiss_backend(session, temp_faiss_dir) -> FaissEmbeddingBackend:
 
 
 @pytest.fixture
-def pgvector_backend(session) -> PGVectorEmbeddingBackend:
+def pgvector_backend(session) -> "PGVectorEmbeddingBackend":
     """PGVector backend with vector extension and model registry initialized."""
+    if PGVectorEmbeddingBackend is None:
+        pytest.skip("pgvector dependency is not installed")
     backend = PGVectorEmbeddingBackend()
     backend.initialise_store(session.bind)
     return backend

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,51 @@
+"""Tests for CLI configuration helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, PropertyMock
+
+import pytest
+
+from omop_emb.cli import _resolve_embedding_dim, _resolve_model_name
+from omop_emb.interface import EmbeddingInterface
+
+
+@pytest.mark.unit
+class TestCliHelpers:
+    def test_resolve_model_name_prefers_cli_value(self, monkeypatch):
+        monkeypatch.setenv("OMOP_EMB_MODEL", "env-model")
+
+        assert _resolve_model_name("cli-model") == "cli-model"
+
+    def test_resolve_model_name_uses_env_value(self, monkeypatch):
+        monkeypatch.setenv("OMOP_EMB_MODEL", "env-model")
+
+        assert _resolve_model_name(None) == "env-model"
+
+    def test_resolve_embedding_dim_prefers_cli_value(self):
+        interface = Mock(spec=EmbeddingInterface)
+
+        assert _resolve_embedding_dim(interface, 1024) == 1024
+
+    def test_resolve_embedding_dim_uses_env_value(self, monkeypatch):
+        interface = Mock(spec=EmbeddingInterface)
+        monkeypatch.setenv("OMOP_EMB_EMBEDDING_DIM", "1536")
+
+        assert _resolve_embedding_dim(interface, None) == 1536
+
+    def test_resolve_embedding_dim_falls_back_to_client(self, monkeypatch):
+        monkeypatch.delenv("OMOP_EMB_EMBEDDING_DIM", raising=False)
+        interface = Mock(spec=EmbeddingInterface)
+        type(interface).embedding_dim = PropertyMock(return_value=768)
+
+        assert _resolve_embedding_dim(interface, None) == 768
+
+    def test_resolve_embedding_dim_raises_with_guidance(self, monkeypatch):
+        monkeypatch.delenv("OMOP_EMB_EMBEDDING_DIM", raising=False)
+        interface = Mock(spec=EmbeddingInterface)
+        type(interface).embedding_dim = PropertyMock(
+            side_effect=NotImplementedError("ollama-only")
+        )
+
+        with pytest.raises(RuntimeError, match="--embedding-dim"):
+            _resolve_embedding_dim(interface, None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 from omop_emb.cli import (
     _normalize_api_base,
     _normalize_embedding_path,
+    _resolve_api_key,
     _resolve_embedding_dim,
     _resolve_model_name,
 )
@@ -54,6 +55,21 @@ class TestCliHelpers:
 
         with pytest.raises(RuntimeError, match="--embedding-dim"):
             _resolve_embedding_dim(interface, None)
+
+    def test_resolve_api_key_uses_cli_value(self, monkeypatch):
+        monkeypatch.setenv("OMOP_EMB_API_KEY", "env-key")
+
+        assert _resolve_api_key("cli-key") == "cli-key"
+
+    def test_resolve_api_key_uses_env_value(self, monkeypatch):
+        monkeypatch.setenv("OMOP_EMB_API_KEY", "env-key")
+
+        assert _resolve_api_key(None) == "env-key"
+
+    def test_resolve_api_key_allows_missing_value(self, monkeypatch):
+        monkeypatch.delenv("OMOP_EMB_API_KEY", raising=False)
+
+        assert _resolve_api_key(None) is None
 
     def test_normalize_api_base_strips_embeddings_suffix(self):
         assert _normalize_api_base("http://localhost:8000/v1/embeddings", "/embeddings") == "http://localhost:8000/v1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import Mock, PropertyMock
 
 import pytest
@@ -12,12 +13,15 @@ from omop_emb.backends.config import BackendType, IndexType
 from omop_emb.cli import (
     _build_backend_metadata,
     _build_concept_filter,
+    _load_batch_queries,
     _normalize_api_base,
     _normalize_embedding_path,
+    _render_search_results,
     _resolve_api_key,
     _resolve_embedding_dim,
     add_embeddings,
     _resolve_model_name,
+    search_batch,
     switch_index_type,
 )
 from omop_emb.interface import EmbeddingInterface
@@ -131,6 +135,32 @@ class TestCliHelpers:
         assert "hnsw_ef_search" not in metadata
         assert metadata["custom"] == "keep-me"
 
+    def test_load_batch_queries_supports_optional_query_ids(self, tmp_path: Path):
+        query_file = tmp_path / "queries.txt"
+        query_file.write_text("q1\talpha\nbeta\n\nq3\tgamma\n", encoding="utf-8")
+
+        assert _load_batch_queries(str(query_file)) == [
+            ("q1", "alpha"),
+            ("2", "beta"),
+            ("q3", "gamma"),
+        ]
+
+    def test_render_search_results_handles_empty_match_list(self):
+        assert _render_search_results(query_id="q1", query_text="alpha", matches=()) == [
+            "q1\talpha\t0\t\t\t"
+        ]
+
+    def test_render_search_results_formats_rows(self):
+        match = Mock(concept_id=123, similarity=0.9, concept_name="Alpha concept")
+
+        assert _render_search_results(
+            query_id="q1",
+            query_text="alpha",
+            matches=(match,),
+        ) == [
+            "q1\talpha\t1\t123\t0.900000\tAlpha concept"
+        ]
+
     def test_add_embeddings_prints_faiss_rebuild_note(self, monkeypatch, capsys):
         class FakeResult:
             def partitions(self, batch_size):
@@ -217,6 +247,70 @@ class TestCliHelpers:
         stdout = capsys.readouterr().out
         assert "Rebuild the metric-specific FAISS index before search" in stdout
         assert "omop-emb rebuild-index --model tei-qwen:intfloat/multilingual-e5-large-instruct" in stdout
+
+    def test_search_batch_warms_index_once_and_prints_results(self, monkeypatch, capsys, tmp_path: Path):
+        class FakeSession:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return None
+
+        match = Mock(concept_id=123, similarity=0.9, concept_name="Alpha concept")
+        fake_interface = Mock(spec=EmbeddingInterface)
+        fake_interface.backend = Mock()
+        fake_interface.backend.backend_type = BackendType.FAISS
+        fake_interface.backend.backend_name = "faiss"
+        fake_interface.initialise_store.return_value = None
+
+        query_file = tmp_path / "queries.txt"
+        query_file.write_text("q1\talpha\nq2\tbeta\n", encoding="utf-8")
+
+        monkeypatch.setattr(cli_module, "_create_engine_from_env", lambda: object())
+        monkeypatch.setattr(cli_module, "get_metadata_schema", lambda: "public")
+        monkeypatch.setattr(
+            cli_module,
+            "_create_embedding_interface",
+            lambda **kwargs: (fake_interface, "tei-qwen:intfloat/multilingual-e5-large-instruct"),
+        )
+        monkeypatch.setattr(cli_module, "Session", lambda engine: FakeSession())
+
+        warmed = []
+        searched = []
+
+        monkeypatch.setattr(
+            cli_module,
+            "_warm_search_backend",
+            lambda **kwargs: warmed.append(kwargs["model_name"]),
+        )
+        monkeypatch.setattr(
+            cli_module,
+            "_run_search_query",
+            lambda **kwargs: searched.append(tuple(kwargs["query_texts"])) or ((match,), ()),
+        )
+
+        search_batch(
+            query_file=str(query_file),
+            api_base="http://localhost:14000/v1",
+            api_key=None,
+            batch_size=2,
+            model="tei-qwen:intfloat/multilingual-e5-large-instruct",
+            embedding_path="/embeddings",
+            backend_name="faiss",
+            faiss_base_dir="/tmp/faiss",
+            metric_type=cli_module.MetricType.COSINE,
+            k=5,
+            standard_only=False,
+            vocabularies=None,
+            warm_index=True,
+        )
+
+        assert warmed == ["tei-qwen:intfloat/multilingual-e5-large-instruct"]
+        assert searched == [("alpha", "beta")]
+        stdout = capsys.readouterr().out.strip().splitlines()
+        assert stdout[0] == "query_id\tquery_text\trank\tconcept_id\tsimilarity\tconcept_name"
+        assert stdout[1] == "q1\talpha\t1\t123\t0.900000\tAlpha concept"
+        assert stdout[2] == "q2\tbeta\t0"
 
     def test_switch_index_type_updates_faiss_model_and_rebuilds(self, monkeypatch, capsys):
         class FakeSession:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,12 @@ from unittest.mock import Mock, PropertyMock
 
 import pytest
 
-from omop_emb.cli import _resolve_embedding_dim, _resolve_model_name
+from omop_emb.cli import (
+    _normalize_api_base,
+    _normalize_embedding_path,
+    _resolve_embedding_dim,
+    _resolve_model_name,
+)
 from omop_emb.interface import EmbeddingInterface
 
 
@@ -49,3 +54,15 @@ class TestCliHelpers:
 
         with pytest.raises(RuntimeError, match="--embedding-dim"):
             _resolve_embedding_dim(interface, None)
+
+    def test_normalize_api_base_strips_embeddings_suffix(self):
+        assert _normalize_api_base("http://localhost:8000/v1/embeddings", "/embeddings") == "http://localhost:8000/v1"
+
+    def test_normalize_api_base_leaves_base_url_unchanged(self):
+        assert _normalize_api_base("http://localhost:8000/v1", "/embeddings") == "http://localhost:8000/v1"
+
+    def test_normalize_api_base_strips_custom_embedding_path(self):
+        assert _normalize_api_base("http://localhost:8000/v1/embed", "/embed") == "http://localhost:8000/v1"
+
+    def test_normalize_embedding_path_adds_leading_slash(self):
+        assert _normalize_embedding_path("embed") == "/embed"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,17 +1,24 @@
-"""Tests for CLI configuration helpers."""
+"""Tests for CLI configuration helpers and user-facing messages."""
 
 from __future__ import annotations
 
 from unittest.mock import Mock, PropertyMock
 
 import pytest
+import sqlalchemy as sa
 
+import omop_emb.cli as cli_module
+from omop_emb.backends.config import BackendType, IndexType
 from omop_emb.cli import (
+    _build_backend_metadata,
+    _build_concept_filter,
     _normalize_api_base,
     _normalize_embedding_path,
     _resolve_api_key,
     _resolve_embedding_dim,
+    add_embeddings,
     _resolve_model_name,
+    switch_index_type,
 )
 from omop_emb.interface import EmbeddingInterface
 
@@ -82,3 +89,180 @@ class TestCliHelpers:
 
     def test_normalize_embedding_path_adds_leading_slash(self):
         assert _normalize_embedding_path("embed") == "/embed"
+
+    def test_build_concept_filter_returns_none_when_unfiltered(self):
+        assert _build_concept_filter(standard_only=False, vocabularies=None) is None
+
+    def test_build_concept_filter_returns_filter_when_constrained(self):
+        concept_filter = _build_concept_filter(
+            standard_only=True,
+            vocabularies=["SNOMED"],
+        )
+
+        assert concept_filter is not None
+        assert concept_filter.require_standard is True
+        assert concept_filter.vocabularies == ("SNOMED",)
+
+    def test_build_backend_metadata_includes_hnsw_settings_for_faiss(self):
+        metadata = _build_backend_metadata(
+            backend_type=BackendType.FAISS,
+            index_type=IndexType.HNSW,
+            hnsw_num_neighbors=48,
+            hnsw_ef_search=96,
+            hnsw_ef_construction=240,
+        )
+
+        assert metadata["hnsw_num_neighbors"] == 48
+        assert metadata["hnsw_ef_search"] == 96
+        assert metadata["hnsw_ef_construction"] == 240
+
+    def test_build_backend_metadata_strips_hnsw_settings_for_flat(self):
+        metadata = _build_backend_metadata(
+            backend_type=BackendType.FAISS,
+            index_type=IndexType.FLAT,
+            existing_metadata={
+                "hnsw_num_neighbors": 48,
+                "hnsw_ef_search": 96,
+                "custom": "keep-me",
+            },
+        )
+
+        assert "hnsw_num_neighbors" not in metadata
+        assert "hnsw_ef_search" not in metadata
+        assert metadata["custom"] == "keep-me"
+
+    def test_add_embeddings_prints_faiss_rebuild_note(self, monkeypatch, capsys):
+        class FakeResult:
+            def partitions(self, batch_size):
+                return iter(())
+
+        class FakeReaderSession:
+            bind = object()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return None
+
+            def scalar(self, query):
+                return 0
+
+            def execute(self, query):
+                return FakeResult()
+
+        class FakeWriterSession:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return None
+
+        class FakeInterface:
+            def __init__(self):
+                self.backend = Mock()
+                self.backend.backend_type = BackendType.FAISS
+
+            def initialise_store(self, engine):
+                return None
+
+            def ensure_model_registered(self, **kwargs):
+                return None
+
+            def get_concepts_without_embedding_count(self, **kwargs):
+                return 0
+
+            def get_concepts_without_embedding_query(self, **kwargs):
+                return (
+                    sa.select(
+                        sa.literal(0).label("concept_id"),
+                        sa.literal("").label("concept_name"),
+                    )
+                    .where(sa.false())
+                )
+
+            def embed_and_upsert_concepts(self, **kwargs):
+                return None
+
+        fake_interface = FakeInterface()
+        fake_engine = object()
+        fake_sessions = iter((FakeReaderSession(), FakeWriterSession()))
+
+        monkeypatch.setattr(cli_module, "_create_engine_from_env", lambda: fake_engine)
+        monkeypatch.setattr(cli_module, "get_metadata_schema", lambda: "public")
+        monkeypatch.setattr(
+            cli_module,
+            "_create_embedding_interface",
+            lambda **kwargs: (fake_interface, "tei-qwen:intfloat/multilingual-e5-large-instruct"),
+        )
+        monkeypatch.setattr(cli_module, "_resolve_embedding_dim", lambda interface, embedding_dim: 1024)
+        monkeypatch.setattr(cli_module, "Session", lambda engine: next(fake_sessions))
+
+        add_embeddings(
+            api_base="http://localhost:14000/v1",
+            api_key=None,
+            index_type=IndexType.FLAT,
+            batch_size=32,
+            model="tei-qwen:intfloat/multilingual-e5-large-instruct",
+            embedding_dim=1024,
+            embedding_path="/embeddings",
+            overwrite_model_registration=False,
+            backend_name="faiss",
+            faiss_base_dir="/tmp/faiss",
+            standard_only=False,
+            vocabularies=None,
+            num_embeddings=0,
+        )
+
+        stdout = capsys.readouterr().out
+        assert "Rebuild the metric-specific FAISS index before search" in stdout
+        assert "omop-emb rebuild-index --model tei-qwen:intfloat/multilingual-e5-large-instruct" in stdout
+
+    def test_switch_index_type_updates_faiss_model_and_rebuilds(self, monkeypatch, capsys):
+        class FakeSession:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return None
+
+        fake_backend = Mock(spec=cli_module.FaissEmbeddingBackend)
+        fake_backend.backend_type = BackendType.FAISS
+        fake_backend.get_registered_model.return_value = Mock(
+            metadata={"custom": "keep-me"},
+        )
+
+        fake_interface = Mock(spec=EmbeddingInterface)
+        fake_interface.backend = fake_backend
+
+        monkeypatch.setattr(cli_module, "_create_engine_from_env", lambda: object())
+        monkeypatch.setattr(cli_module, "get_metadata_schema", lambda: "public")
+        monkeypatch.setattr(
+            cli_module.EmbeddingInterface,
+            "from_backend_name",
+            classmethod(lambda cls, **kwargs: fake_interface),
+        )
+        monkeypatch.setattr(cli_module, "Session", lambda engine: FakeSession())
+
+        switch_index_type(
+            model="tei-qwen:intfloat/multilingual-e5-large-instruct",
+            backend_name="faiss",
+            faiss_base_dir="/tmp/faiss",
+            index_type=IndexType.HNSW,
+            metric_types=None,
+            hnsw_num_neighbors=48,
+            hnsw_ef_search=96,
+            hnsw_ef_construction=240,
+            batch_size=1000,
+            rebuild=True,
+        )
+
+        fake_backend.update_model_index_configuration.assert_called_once()
+        update_kwargs = fake_backend.update_model_index_configuration.call_args.kwargs
+        assert update_kwargs["index_type"] == IndexType.HNSW
+        assert update_kwargs["metadata"]["hnsw_num_neighbors"] == 48
+        assert update_kwargs["metadata"]["hnsw_ef_search"] == 96
+        assert update_kwargs["metadata"]["hnsw_ef_construction"] == 240
+        fake_interface.rebuild_model_indexes.assert_called_once()
+        stdout = capsys.readouterr().out
+        assert "Updated model 'tei-qwen:intfloat/multilingual-e5-large-instruct' to index_type=hnsw." in stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,11 @@
 """Tests for backend configuration and factory."""
 
 import pytest
+from sqlalchemy.orm import configure_mappers
 
 from omop_emb.backends.factory import normalize_backend_name, get_embedding_backend
 from omop_emb.backends.config import BackendType, IndexType, MetricType
+from omop_emb.backends.registry import ModelRegistry
 
 
 @pytest.mark.unit
@@ -41,3 +43,16 @@ class TestBackendConfig:
             IndexType.HNSW,
             MetricType.COSINE,
         )
+
+    def test_model_registry_accepts_supported_faiss_index_type(self):
+        configure_mappers()
+        row = ModelRegistry(
+            model_name="test-model",
+            dimensions=128,
+            storage_identifier="faiss_test_model",
+            index_type=IndexType.HNSW,
+            backend_type=BackendType.FAISS,
+            details={},
+        )
+
+        assert row.index_type == IndexType.HNSW

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,7 @@ class TestBackendConfig:
         from omop_emb.backends.config import is_index_type_supported_for_backend
         
         assert is_index_type_supported_for_backend(BackendType.FAISS, IndexType.FLAT)
+        assert is_index_type_supported_for_backend(BackendType.FAISS, IndexType.HNSW)
     
     def test_faiss_supports_cosine_metric(self):
         """Test FAISS supports COSINE metric."""
@@ -33,5 +34,10 @@ class TestBackendConfig:
         assert is_supported_index_metric_combination_for_backend(
             BackendType.FAISS,
             IndexType.FLAT,
+            MetricType.COSINE,
+        )
+        assert is_supported_index_metric_combination_for_backend(
+            BackendType.FAISS,
+            IndexType.HNSW,
             MetricType.COSINE,
         )

--- a/tests/test_faiss.py
+++ b/tests/test_faiss.py
@@ -6,7 +6,7 @@ from .shared_backend_tests import SharedBackendTests
 
 
 @pytest.mark.faiss
-@pytest.mark.unit
+@pytest.mark.integration
 class TestFaissBackend(SharedBackendTests):
     """Test FAISS embedding backend."""
 

--- a/tests/test_faiss_storage_manager.py
+++ b/tests/test_faiss_storage_manager.py
@@ -1,0 +1,40 @@
+"""Unit tests for FAISS storage manager rebuild behavior."""
+
+from __future__ import annotations
+
+import pytest
+
+from omop_emb.backends.config import BackendType, IndexType, MetricType
+from omop_emb.backends.faiss.storage_manager import EmbeddingStorageManager
+
+
+@pytest.mark.unit
+def test_rebuild_index_does_not_call_load_or_populate(monkeypatch, tmp_path):
+    storage_manager = EmbeddingStorageManager(
+        file_dir=tmp_path,
+        dimensions=16,
+        backend_type=BackendType.FAISS,
+    )
+
+    events: list[str] = []
+
+    class FakeIndexManager:
+        def load_or_populate(self, data_stream):
+            events.append("load_or_populate")
+
+        def rebuild_from_storage(self, data_stream):
+            events.append("rebuild_from_storage")
+
+    monkeypatch.setattr(
+        storage_manager,
+        "_instantiate_index_manager",
+        lambda **kwargs: FakeIndexManager(),
+    )
+
+    storage_manager.rebuild_index(
+        index_type=IndexType.HNSW,
+        metric_type=MetricType.COSINE,
+        batch_size=10,
+    )
+
+    assert events == ["rebuild_from_storage"]

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -6,7 +6,7 @@ from omop_alchemy.cdm.model.vocabulary import Concept
 from .conftest import CONCEPTS, EMBEDDING_DIM
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 class TestFixtures:
     """Test that fixtures and database setup work."""
     

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -8,6 +8,9 @@ from sqlalchemy.orm import Session
 from omop_emb.interface import EmbeddingInterface
 from omop_emb.backends.config import IndexType, MetricType
 from omop_emb.backends.base import NearestConceptMatch
+from omop_emb.backends.embedding_utils import EmbeddingModelRecord
+from omop_emb.backends.config import BackendType
+from omop_emb.backends.errors import ModelRegistrationConflictError
 from .conftest import CONCEPTS, MODEL_NAME, EMBEDDING_DIM
 
 
@@ -47,6 +50,71 @@ class TestInterface:
         )
         
         assert m1.storage_identifier == m2.storage_identifier
+
+    def test_model_registration_dimension_conflict_raises(self, mock_llm_client):
+        backend = Mock()
+        backend.get_registered_model.return_value = EmbeddingModelRecord(
+            model_name=MODEL_NAME,
+            dimensions=1024,
+            backend_type=BackendType.FAISS,
+            index_type=IndexType.FLAT,
+            storage_identifier="faiss_test_model",
+        )
+        interface = EmbeddingInterface(
+            embedding_client=mock_llm_client,
+            backend=backend,
+        )
+
+        with pytest.raises(ModelRegistrationConflictError) as excinfo:
+            interface.ensure_model_registered(
+                engine=Mock(),
+                session=Mock(),
+                model_name=MODEL_NAME,
+                dimensions=512,
+                index_type=IndexType.FLAT,
+            )
+
+        assert excinfo.value.conflict_field == "dimensions"
+
+    def test_model_registration_dimension_conflict_overwrites_when_requested(self, mock_llm_client):
+        backend = Mock()
+        backend.get_registered_model.return_value = EmbeddingModelRecord(
+            model_name=MODEL_NAME,
+            dimensions=1024,
+            backend_type=BackendType.FAISS,
+            index_type=IndexType.FLAT,
+            storage_identifier="faiss_test_model",
+        )
+        backend.register_model.return_value = EmbeddingModelRecord(
+            model_name=MODEL_NAME,
+            dimensions=512,
+            backend_type=BackendType.FAISS,
+            index_type=IndexType.FLAT,
+            storage_identifier="faiss_test_model",
+        )
+        interface = EmbeddingInterface(
+            embedding_client=mock_llm_client,
+            backend=backend,
+        )
+        engine = Mock()
+        session = Mock()
+
+        model = interface.ensure_model_registered(
+            engine=engine,
+            session=session,
+            model_name=MODEL_NAME,
+            dimensions=512,
+            index_type=IndexType.FLAT,
+            overwrite_existing_conflicts=True,
+        )
+
+        backend.delete_model.assert_called_once_with(
+            engine=engine,
+            session=session,
+            model_name=MODEL_NAME,
+        )
+        backend.register_model.assert_called_once()
+        assert model.dimensions == 512
     
     def test_is_model_registered(self, session, embedding_interface: EmbeddingInterface):
         """Test checking model registration status."""

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -211,6 +211,23 @@ class TestInterface:
         embeddings = embedding_interface.embed_texts(texts)
         
         assert embeddings.shape == (len(texts), EMBEDDING_DIM)
+
+    @pytest.mark.unit
+    def test_rebuild_model_indexes_delegates_to_backend(self, mock_llm_client):
+        backend = Mock()
+        interface = EmbeddingInterface(
+            embedding_client=mock_llm_client,
+            backend=backend,
+        )
+
+        interface.rebuild_model_indexes(
+            session=Mock(),
+            model_name=MODEL_NAME,
+            metric_types=(MetricType.COSINE,),
+            batch_size=4096,
+        )
+
+        backend.rebuild_model_indexes.assert_called_once()
     
     @pytest.mark.integration
     def test_embed_and_upsert(self, session, embedding_interface: EmbeddingInterface):

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -14,10 +14,10 @@ from omop_emb.backends.errors import ModelRegistrationConflictError
 from .conftest import CONCEPTS, MODEL_NAME, EMBEDDING_DIM
 
 
-@pytest.mark.unit
 class TestInterface:
     """Test EmbeddingInterface core functionality."""
-    
+
+    @pytest.mark.integration
     def test_register_model(self, session, embedding_interface: EmbeddingInterface):
         """Test registering an embedding model."""
         model = embedding_interface.ensure_model_registered(
@@ -31,6 +31,7 @@ class TestInterface:
         assert model.model_name == MODEL_NAME
         assert model.dimensions == EMBEDDING_DIM
     
+    @pytest.mark.integration
     def test_model_registration_idempotent(self, session, embedding_interface: EmbeddingInterface):
         """Test registering same model twice returns existing."""
         m1 = embedding_interface.ensure_model_registered(
@@ -51,6 +52,7 @@ class TestInterface:
         
         assert m1.storage_identifier == m2.storage_identifier
 
+    @pytest.mark.unit
     def test_model_registration_dimension_conflict_raises(self, mock_llm_client):
         backend = Mock()
         backend.get_registered_model.return_value = EmbeddingModelRecord(
@@ -76,6 +78,7 @@ class TestInterface:
 
         assert excinfo.value.conflict_field == "dimensions"
 
+    @pytest.mark.unit
     def test_model_registration_dimension_conflict_overwrites_when_requested(self, mock_llm_client):
         backend = Mock()
         backend.get_registered_model.return_value = EmbeddingModelRecord(
@@ -116,6 +119,7 @@ class TestInterface:
         backend.register_model.assert_called_once()
         assert model.dimensions == 512
     
+    @pytest.mark.integration
     def test_is_model_registered(self, session, embedding_interface: EmbeddingInterface):
         """Test checking model registration status."""
         assert not embedding_interface.is_model_registered(session, MODEL_NAME)
@@ -130,20 +134,31 @@ class TestInterface:
         
         assert embedding_interface.is_model_registered(session, MODEL_NAME)
     
-    def test_embed_texts(self, embedding_interface: EmbeddingInterface):
+    @pytest.mark.unit
+    def test_embed_texts(self, mock_llm_client):
         """Test embedding generation."""
+        embedding_interface = EmbeddingInterface(
+            embedding_client=mock_llm_client,
+            backend=Mock(),
+        )
         embeddings = embedding_interface.embed_texts(CONCEPTS["Hypertension"].concept_name)
         
         assert embeddings.shape == (1, EMBEDDING_DIM)
         assert embeddings.dtype == np.float32
     
-    def test_embed_multiple_texts(self, embedding_interface: EmbeddingInterface):
+    @pytest.mark.unit
+    def test_embed_multiple_texts(self, mock_llm_client):
         """Test embedding multiple texts."""
+        embedding_interface = EmbeddingInterface(
+            embedding_client=mock_llm_client,
+            backend=Mock(),
+        )
         texts = [c.concept_name for c in CONCEPTS.values()]
         embeddings = embedding_interface.embed_texts(texts)
         
         assert embeddings.shape == (len(texts), EMBEDDING_DIM)
     
+    @pytest.mark.integration
     def test_embed_and_upsert(self, session, embedding_interface: EmbeddingInterface):
         """Test embedding and upserting concepts."""
         embedding_interface.ensure_model_registered(
@@ -168,6 +183,7 @@ class TestInterface:
         assert embeddings.shape == (2, EMBEDDING_DIM)
         assert embedding_interface.has_any_embeddings(session, MODEL_NAME)
     
+    @pytest.mark.integration
     def test_get_embeddings_by_concept_ids(self, session, embedding_interface: EmbeddingInterface):
         """Test retrieving stored embeddings."""
         embedding_interface.ensure_model_registered(
@@ -198,8 +214,9 @@ class TestInterface:
         assert len(retrieved) == 2
         assert 1 in retrieved and 2 in retrieved
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("backend_name", ["faiss", "pgvector"])
-    def test_search_return_structure_for_backends(self, session, mock_llm_client, backend_name):
+    def test_search_return_structure_for_backends(self, mock_llm_client, backend_name):
         """Search returns tuple[dict[int, float], ...] for both backend modes."""
         mock_backend = Mock()
         mock_backend.get_nearest_concepts.return_value = (
@@ -228,7 +245,7 @@ class TestInterface:
 
         query_embedding = np.zeros((1, EMBEDDING_DIM), dtype=np.float32)
         result = interface.get_nearest_concepts(
-            session=session,
+            session=Mock(),
             model_name=MODEL_NAME,
             query_embedding=query_embedding,
             metric_type=MetricType.COSINE,

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -118,6 +118,60 @@ class TestInterface:
         )
         backend.register_model.assert_called_once()
         assert model.dimensions == 512
+
+    @pytest.mark.unit
+    def test_model_registration_overwrite_rebuilds_even_without_conflict(self, mock_llm_client):
+        backend = Mock()
+        backend.register_model.return_value = EmbeddingModelRecord(
+            model_name=MODEL_NAME,
+            dimensions=512,
+            backend_type=BackendType.FAISS,
+            index_type=IndexType.FLAT,
+            storage_identifier="faiss_test_model",
+        )
+        interface = EmbeddingInterface(
+            embedding_client=mock_llm_client,
+            backend=backend,
+        )
+        engine = Mock()
+        session = Mock()
+
+        model = interface.ensure_model_registered(
+            engine=engine,
+            session=session,
+            model_name=MODEL_NAME,
+            dimensions=512,
+            index_type=IndexType.FLAT,
+            overwrite_existing_conflicts=True,
+        )
+
+        backend.delete_model.assert_called_once_with(
+            engine=engine,
+            session=session,
+            model_name=MODEL_NAME,
+        )
+        backend.get_registered_model.assert_not_called()
+        backend.register_model.assert_called_once()
+        assert model.dimensions == 512
+
+    @pytest.mark.unit
+    def test_model_registration_raises_for_stale_backend_artifacts(self, mock_llm_client):
+        backend = Mock()
+        backend.get_registered_model.return_value = None
+        backend.has_stale_model_artifacts.return_value = True
+        interface = EmbeddingInterface(
+            embedding_client=mock_llm_client,
+            backend=backend,
+        )
+
+        with pytest.raises(RuntimeError, match="overwrite-model-registration"):
+            interface.ensure_model_registered(
+                engine=Mock(),
+                session=Mock(),
+                model_name=MODEL_NAME,
+                dimensions=512,
+                index_type=IndexType.FLAT,
+            )
     
     @pytest.mark.integration
     def test_is_model_registered(self, session, embedding_interface: EmbeddingInterface):

--- a/tests/test_pgvector.py
+++ b/tests/test_pgvector.py
@@ -6,7 +6,7 @@ from .shared_backend_tests import SharedBackendTests
 
 
 @pytest.mark.pgvector
-@pytest.mark.unit
+@pytest.mark.integration
 class TestPGVectorBackend(SharedBackendTests):
     """Test pgvector embedding backend."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1406,6 +1406,7 @@ dependencies = [
     { name = "omop-llm" },
     { name = "orm-loader" },
     { name = "psycopg2-binary" },
+    { name = "requests" },
     { name = "sqlalchemy" },
     { name = "typing-extensions" },
 ]
@@ -1450,6 +1451,7 @@ requires-dist = [
     { name = "pgvector", marker = "extra == 'all'" },
     { name = "pgvector", marker = "extra == 'pgvector'" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
+    { name = "requests", specifier = ">=2.31" },
     { name = "sqlalchemy", specifier = ">=2.0.45" },
     { name = "typing-extensions", specifier = ">=4.15.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1398,7 +1398,7 @@ wheels = [
 
 [[package]]
 name = "omop-emb"
-version = "0.2.2"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
This pull request brings in a number of commits that do the following:
- adds a new parameter/env variable to pass in the embedding dimension b/c some APIs do not provide an endpoint for checking it
- logs the actual selection query and the real number of concepts returned before processing
- stops attempting to recreate the entire OMOP database if one exists already (create only the embedding model registry / backend-specific storage metadata needed by `omop-emb`)
- fixes an error that was initialization-order bug 
- enables an OpenAI conformant local embedding client and support for custom endpoint paths like `/embeddings` or `/embed`
- enables --api-key to be None b/c some API shims manage auth by configuration behind the service
- implements the ability to change the specified dimension of an embedding model that was previously registered (e.g., moving from a 1024 to 512 version of a particular model)
- hardens the FAISS unit tests and detangles them from integration and DB-backend tests
- adds several FAISS scalability revisions so that millions of concepts can be better managed