### PR TITLE
fix: Add asymmetric embedding model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ Common environment variables:
 - `OMOP_EMB_BACKEND`: backend name (`pgvector` or `faiss`) used by the backend factory.
 - `OMOP_EMB_BASE_STORAGE_DIR`: local base directory for `omop-emb` artifacts, including local metadata (`metadata.db`) and FAISS files. If unset, `omop-emb` defaults to `./.omop_emb` in the current working directory.
 - `OMOP_DATABASE_URL`: SQLAlchemy URL for the OMOP CDM database.
+- `OMOP_EMB_DOCUMENT_EMBEDDING_PREFIX`: task prefix prepended to concept texts at index time. Required for asymmetric models (e.g. `search_document: ` for nomic-embed-text, `passage: ` for E5).
+- `OMOP_EMB_QUERY_EMBEDDING_PREFIX`: task prefix prepended to search queries at query time. Required for asymmetric models (e.g. `search_query: ` for nomic-embed-text, `query: ` for E5).
+
+The prefix variables default to `""` and are safe to omit for symmetric models. See [Asymmetric Embeddings](https://AustralianCancerDataNetwork.github.io/omop-emb/usage/asymmetric-embeddings/) for details.
 
 Extended documentation can be found [here](https://AustralianCancerDataNetwork.github.io/omop-emb).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,11 +31,17 @@ At runtime, backend choice should also be explicit. The intended direction is:
 - install-time choice via extras
 - runtime choice via config such as `OMOP_EMB_BACKEND=pgvector` or `OMOP_EMB_BACKEND=faiss` or passing it as an argument to the respective interface (e.g. see [CLI reference](usage/cli.md))
 
-Recommended runtime environment variables:
+## Environment Variables { data-toc-label="Environment Variables" }
 
-- **`OMOP_EMB_BACKEND`**: `pgvector` or `faiss`
-- **`OMOP_EMB_BASE_STORAGE_DIR`**: base directory for local metadata and FAISS artifacts; defaults to `omop_emb/.omop_emb` the root direcotry of hte package.
-- **`OMOP_DATABASE_URL`**: OMOP CDM database URL
+| Variable | Description | Details |
+|---|---|---|
+| `OMOP_EMB_BACKEND` | Backend to use: `pgvector` or `faiss` | [Embedding Storage](usage/backend-selection.md) |
+| `OMOP_EMB_BASE_STORAGE_DIR` | Base directory for `metadata.db` and FAISS artifacts | [Installation](usage/installation.md) |
+| `OMOP_DATABASE_URL` | SQLAlchemy URL for the OMOP CDM database | [Installation](usage/installation.md) |
+| `OMOP_EMB_DOCUMENT_EMBEDDING_PREFIX` | Task prefix prepended to concept texts at index time | [Asymmetric Embeddings](usage/asymmetric-embeddings.md) |
+| `OMOP_EMB_QUERY_EMBEDDING_PREFIX` | Task prefix prepended to search queries at query time | [Asymmetric Embeddings](usage/asymmetric-embeddings.md) |
+
+The prefix variables are optional and default to `""`. They are only needed for asymmetric embedding models (e.g. nomic-embed-text, E5, BGE) that require different task prefixes for indexing versus searching.
 
 
 !!! info "Important caveats"

--- a/docs/usage/asymmetric-embeddings.md
+++ b/docs/usage/asymmetric-embeddings.md
@@ -1,0 +1,111 @@
+# Asymmetric Embeddings { data-toc-label="Asymmetric Embeddings" }
+
+## What are asymmetric embedding models?
+
+Most general-purpose models (e.g. `text-embedding-3-small`) produce vectors in a symmetric space: the same transformation is applied whether you are indexing a document or submitting a search query.
+
+**Asymmetric models** — such as [nomic-embed-text](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5), [E5](https://huggingface.co/intfloat/e5-large-v2), and [BGE](https://huggingface.co/BAAI/bge-large-en-v1.5) — are trained with *task-specific prefixes* prepended to the input. The model's training objective explicitly separates the representation space for documents being indexed from the space for queries being searched. Sending text without the correct prefix does not raise an error, but similarity scores degrade substantially and silently.
+
+## Why it matters for OMOP concept search
+
+In `omop-emb` there are two distinct embedding roles:
+
+| Role | Example texts | Purpose |
+|------|--------------|---------|
+| **Document** | `"Hypertension"`, `"Type 2 diabetes mellitus"` | Concepts stored in the vector index |
+| **Query** | `"high blood pressure"`, `"T2DM"` | Free-text search terms at query time |
+
+For a symmetric model these are interchangeable. For an asymmetric model the document prefix must be applied to every concept at index time, and the query prefix to every search term at query time. Mixing the two reduces retrieval quality without any visible error.
+
+## Configuration
+
+`omop-emb` reads two environment variables when `EmbeddingClient` is constructed:
+
+| Variable | Role | Example value |
+|---|---|---|
+| `OMOP_EMB_DOCUMENT_EMBEDDING_PREFIX` | Prepended to all **document** texts before indexing | `search_document: ` |
+| `OMOP_EMB_QUERY_EMBEDDING_PREFIX` | Prepended to all **query** texts before searching | `search_query: ` |
+
+Both default to `""`. When either is empty, `omop-emb` logs a warning at startup explaining what the variable is for. This is not an error — it is correct behaviour for symmetric models.
+
+!!! tip "Prefix examples by model family"
+    | Model | Document prefix | Query prefix |
+    |---|---|---|
+    | `nomic-embed-text:v1.5` | `search_document: ` | `search_query: ` |
+    | `e5-large-v2` | `passage: ` | `query: ` |
+    | `bge-large-en-v1.5` | *(none)* | `Represent this sentence for searching relevant passages: ` |
+
+    Always check the model card — task prefixes are model-specific and can change between versions.
+
+## Role assignment in the API
+
+The two high-level methods handle roles automatically. You only need to think about roles when calling `embed_texts` directly.
+
+### Indexing concepts — `DOCUMENT` is automatic
+
+`embed_and_upsert_concepts` always uses `EmbeddingRole.DOCUMENT`:
+
+```python
+interface.embed_and_upsert_concepts(
+    session=session,
+    index_type=IndexType.FLAT,
+    concept_ids=(1, 2, 3),
+    concept_texts=("Hypertension", "Diabetes", "Aspirin"),
+)
+```
+
+### Querying — `QUERY` is automatic
+
+`get_nearest_concepts_from_query_texts` always uses `EmbeddingRole.QUERY`:
+
+```python
+results = interface.get_nearest_concepts_from_query_texts(
+    session=session,
+    index_type=IndexType.FLAT,
+    query_texts=("high blood pressure",),
+    metric_type=MetricType.COSINE,
+)
+```
+
+### Direct embedding generation — caller chooses the role
+
+When you call `embed_texts` directly you must pass the role explicitly:
+
+```python
+from omop_emb.embeddings import EmbeddingRole
+
+# Indexing — use DOCUMENT
+doc_embeddings = interface.embed_texts(
+    ["Hypertension", "Diabetes"],
+    embedding_role=EmbeddingRole.DOCUMENT,
+)
+
+# Searching — use QUERY
+query_embeddings = interface.embed_texts(
+    ["high blood pressure"],
+    embedding_role=EmbeddingRole.QUERY,
+)
+```
+
+Similarly, `EmbeddingClient.embeddings()` and `EmbeddingClient.similarity()` require explicit roles:
+
+```python
+# embeddings()
+vecs = client.embeddings(texts, embedding_role=EmbeddingRole.DOCUMENT)
+
+# similarity() — terms_role for the first argument, terms_to_match_role for the second
+scores = client.similarity(
+    "high blood pressure",
+    "Hypertension",
+    terms_role=EmbeddingRole.QUERY,
+    terms_to_match_role=EmbeddingRole.DOCUMENT,
+)
+```
+
+### Inspecting active prefixes
+
+```python
+print(client.embedding_role_prefixes())
+# {<EmbeddingRole.DOCUMENT: 'document'>: 'search_document: ',
+#  <EmbeddingRole.QUERY: 'query'>: 'search_query: '}
+```

--- a/docs/usage/interface-guide.md
+++ b/docs/usage/interface-guide.md
@@ -57,7 +57,12 @@ interface.embed_and_upsert_concepts(
 )
 
 # Or generate and upsert separately
-embeddings = interface.embed_texts(["Hypertension", "Diabetes"])
+from omop_emb.embeddings import EmbeddingRole
+
+embeddings = interface.embed_texts(
+    ["Hypertension", "Diabetes"],
+    embedding_role=EmbeddingRole.DOCUMENT,
+)
 interface.upsert_concept_embeddings(
     session=session,
     index_type=IndexType.FLAT,
@@ -65,6 +70,9 @@ interface.upsert_concept_embeddings(
     embeddings=embeddings,
 )
 ```
+
+!!! info "Asymmetric embedding models"
+    `embed_and_upsert_concepts` always applies the **document** role, and `get_nearest_concepts_from_query_texts` always applies the **query** role. When calling `embed_texts` directly you must pass `embedding_role` explicitly. See [Asymmetric Embeddings](asymmetric-embeddings.md) for how to configure task prefixes.
 
 ### Query nearest concepts
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
       - Installation: usage/installation.md
       - Embedding Storage: usage/backend-selection.md
       - Interfaces: usage/interface-guide.md
+      - Asymmetric Embeddings: usage/asymmetric-embeddings.md
       - "CLI Reference": usage/cli.md
 
 plugins:

--- a/src/omop_emb/config.py
+++ b/src/omop_emb/config.py
@@ -2,7 +2,9 @@ from enum import StrEnum
 from typing import Dict, Tuple
 
 ENV_OMOP_EMB_BACKEND = "OMOP_EMB_BACKEND"
-ENV_BASE_STORAGE_DIR = "OMOP_EMB_BASE_STORAGE_DIR"  # For backends that use file-based storage, e.g. FAISS with on-disk indices or registry metadata storage
+ENV_BASE_STORAGE_DIR = "OMOP_EMB_BASE_STORAGE_DIR"
+ENV_DOCUMENT_EMBEDDING_PREFIX = "OMOP_EMB_DOCUMENT_EMBEDDING_PREFIX"
+ENV_QUERY_EMBEDDING_PREFIX = "OMOP_EMB_QUERY_EMBEDDING_PREFIX"
 
 class ProviderType(StrEnum):
     """Enum for supported embedding model providers."""

--- a/src/omop_emb/embeddings/__init__.py
+++ b/src/omop_emb/embeddings/__init__.py
@@ -1,4 +1,8 @@
-from .embedding_client import EmbeddingClient
+from .embedding_client import (
+    EmbeddingClient, 
+    EmbeddingClientError, 
+    EmbeddingRole
+)
 from .embedding_providers import (
     EmbeddingProvider,
     get_provider_for_api_base,

--- a/src/omop_emb/embeddings/embedding_client.py
+++ b/src/omop_emb/embeddings/embedding_client.py
@@ -9,16 +9,25 @@ in the omop-emb registry.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple, TypeAlias, Union
+logger = logging.getLogger(__name__)
+import os
+from typing import Any, List, Optional, Tuple, Union, Dict
+from enum import StrEnum
 
 import numpy as np
 from openai import OpenAI
 
 from .embedding_providers import EmbeddingProvider, get_provider_for_api_base
+from omop_emb.config import (
+    ENV_DOCUMENT_EMBEDDING_PREFIX,
+    ENV_QUERY_EMBEDDING_PREFIX,
+)
 
-logger = logging.getLogger(__name__)
 
-CHAT_MESSAGE_DICT: TypeAlias = Dict[str, str]
+class EmbeddingRole(StrEnum):
+    """Enum for embedding roles, used to apply different prefixes to texts based on their role."""
+    DOCUMENT = "document"
+    QUERY = "query"
 
 
 class EmbeddingClientError(RuntimeError):
@@ -63,7 +72,17 @@ class EmbeddingClient:
         self._embedding_batch_size = embedding_batch_size
         self._embedding_dim: Optional[int] = None
         self._base_client = OpenAI(base_url=api_base, api_key=api_key)
-        logger.info(f"EmbeddingClient initialised for model={self._model!r}")
+        doc_prefix, query_prefix = self.load_embedding_prefixes()
+
+        self._embedding_prefixes = {
+            EmbeddingRole.DOCUMENT: doc_prefix,
+            EmbeddingRole.QUERY: query_prefix,
+        }
+
+        logger.info(
+            f"{EmbeddingClient.__name__} initialised for model={self._model!r}.\n"
+            f"URL: {self._base_client.base_url} | Provider: {type(self._provider).__name__}"
+        )
 
     @property
     def provider(self) -> EmbeddingProvider:
@@ -88,6 +107,11 @@ class EmbeddingClient:
     @property
     def base_client(self) -> OpenAI:
         return self._base_client
+    
+    def embedding_role_prefixes(self) -> Dict[EmbeddingRole, str]:
+        """Return a mapping of embedding roles to their configured prefixes."""
+        return self._embedding_prefixes
+
 
     @property
     def embedding_dim(self) -> int:
@@ -115,6 +139,7 @@ class EmbeddingClient:
     def embeddings(
         self,
         text: Union[str, List[str], Tuple[str, ...]],
+        embedding_role: EmbeddingRole,
         batch_size: Optional[int] = None,
     ) -> np.ndarray:
         """Generate embeddings for one or more texts.
@@ -123,6 +148,8 @@ class EmbeddingClient:
         ----------
         text : str | list[str] | tuple[str, ...]
             Input text(s) to embed.
+        embedding_role : EmbeddingRole
+            Role of the input text(s), used to apply different prefixes based on the role.
         batch_size : int, optional
             Overrides ``embedding_batch_size`` for this call.
 
@@ -138,6 +165,8 @@ class EmbeddingClient:
             text = (text,)
         elif isinstance(text, list):
             text = tuple(text)
+            
+        text = self._apply_embedding_prefix(text, text_role=embedding_role)
 
         buffer: list[list[float]] = []
         for start in range(0, len(text), batch_size):
@@ -159,18 +188,20 @@ class EmbeddingClient:
         self,
         terms: Union[str, List[str], np.ndarray],
         terms_to_match: Union[str, List[str], np.ndarray],
+        terms_role: EmbeddingRole,
+        terms_to_match_role: EmbeddingRole,
         **kwargs: Any,
     ) -> np.ndarray:
         """Cosine-similarity matrix between two sets of terms or embeddings."""
         if isinstance(terms, (str, list)):
-            terms = self.embeddings(terms, **kwargs)
+            terms = self.embeddings(terms, embedding_role=terms_role, **kwargs)
         if isinstance(terms_to_match, (str, list)):
-            terms_to_match = self.embeddings(terms_to_match, **kwargs)
+            terms_to_match = self.embeddings(terms_to_match, embedding_role=terms_to_match_role, **kwargs)
         return self.cosine_similarity(terms, terms_to_match)
 
     @staticmethod
     def cosine_similarity(vecs_a: np.ndarray, vecs_b: np.ndarray) -> np.ndarray:
-        """Cosine similarity between row-vector matrices (M×D, N×D → M×N)."""
+        """Cosine similarity between row-vector matrices (MxD, NxD → MxN)."""
         if vecs_a.ndim != 2 or vecs_b.ndim != 2:
             raise RuntimeError(f"Expected 2-D arrays, got shapes {vecs_a.shape} and {vecs_b.shape}")
         norm_a = np.linalg.norm(vecs_a, axis=1, keepdims=True)
@@ -179,8 +210,75 @@ class EmbeddingClient:
         norm_b[norm_b == 0] = 1e-10
         return np.dot(vecs_a / norm_a, (vecs_b / norm_b).T)
 
-    def euclidean_distance(self, text1: str, text2: str) -> float:
+    @staticmethod
+    def l2_norm(vecs_a: np.ndarray, vecs_b: np.ndarray) -> float:
+        """L2 norm between row-vector matrices (MxD, NxD → MxN)."""
+        return float(np.linalg.norm(vecs_a - vecs_b))
+    
+
+    def euclidean_distance(
+        self,
+        text1: str,
+        text2: str,
+        text1_role: EmbeddingRole,
+        text2_role: EmbeddingRole,
+    ) -> float:
         """Euclidean distance between embeddings of two texts."""
-        a = self.embeddings(text1)
-        b = self.embeddings(text2)
+        a = self.embeddings(text1, embedding_role=text1_role)
+        b = self.embeddings(text2, embedding_role=text2_role)
         return float(np.linalg.norm(a - b))
+        
+
+    @staticmethod
+    def load_embedding_prefixes() -> Tuple[str, str]:
+        """Load embedding prefixes for document and query roles from environment variables.
+
+        Returns
+        -------
+        Tuple[str, str]
+            A tuple containing the document embedding prefix and the query embedding prefix.
+        """
+        document_embedding_prefix = os.getenv(ENV_DOCUMENT_EMBEDDING_PREFIX, "")
+        query_embedding_prefix = os.getenv(ENV_QUERY_EMBEDDING_PREFIX, "")
+
+        for role, prefix, var_name in [
+            (EmbeddingRole.DOCUMENT, document_embedding_prefix, ENV_DOCUMENT_EMBEDDING_PREFIX),
+            (EmbeddingRole.QUERY, query_embedding_prefix, ENV_QUERY_EMBEDDING_PREFIX),
+        ]:
+            if prefix:
+                logger.info(
+                    f"{role.value.capitalize()} embedding prefix loaded from {var_name}={prefix!r}. "
+                    f"All {role.value} texts will be prepended with this prefix."
+                )
+            else:
+                logger.warning(
+                    f"{role.value.capitalize()} embedding prefix is not set ({var_name} is empty). "
+                    f"This is fine for symmetric models. For asymmetric models (e.g. nomic-embed-text, "
+                    f"E5, BGE), set {var_name} to the required task prefix.\n"
+                    f"Example (nomic-embed-text): {ENV_DOCUMENT_EMBEDDING_PREFIX}='search_document: ' for {EmbeddingRole.DOCUMENT.value} "
+                    f"and {ENV_QUERY_EMBEDDING_PREFIX}='search_query: ' for {EmbeddingRole.QUERY.value}."
+                )
+
+        return document_embedding_prefix, query_embedding_prefix
+    
+    def _apply_embedding_prefix(
+        self,
+        texts: str | Tuple[str, ...] | List[str],
+        *,
+        text_role: EmbeddingRole,
+    ) -> str | Tuple[str, ...] | List[str]:
+        
+        try:
+            prefix = self._embedding_prefixes[text_role]
+        except KeyError:
+            raise ValueError(f"Invalid embedding role {text_role!r}. Expected one of {[role.value for role in EmbeddingRole]}.")
+        
+        if not prefix:
+            return texts
+        if isinstance(texts, str):
+            return f"{prefix}{texts}"
+        if isinstance(texts, tuple):
+            return tuple(f"{prefix}{text}" for text in texts)
+        if isinstance(texts, list):
+            return [f"{prefix}{text}" for text in texts]
+        raise ValueError(f"Invalid type for texts: {type(texts)}. Expected str, list, or tuple.")

--- a/src/omop_emb/interface.py
+++ b/src/omop_emb/interface.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
-from typing import Mapping, Optional, Sequence, Tuple, List
+from typing import Mapping, Optional, Sequence, Tuple, List, TypeAlias, Literal
+import os
 
 import numpy as np
 from numpy import ndarray
 from sqlalchemy import Engine, Select
 from sqlalchemy.orm import Session
 
-from omop_emb.embeddings import EmbeddingClient, get_provider_from_provider_type
+from omop_emb.embeddings import (
+    EmbeddingClient, 
+    get_provider_from_provider_type,
+    EmbeddingRole
+)
 
 from .backends import get_embedding_backend
 from omop_emb.utils.embedding_utils import EmbeddingConceptFilter
 from omop_emb.model_registry import EmbeddingModelRecord
 from .config import BackendType, IndexType, MetricType, ProviderType
-
-
 
 def list_registered_models(
     backend_name_or_type: Optional[str | BackendType] = None,
@@ -171,7 +174,7 @@ class EmbeddingReaderInterface:
         else:
             raise ValueError(
                 f"Invalid provider_name_or_type: expected str or ProviderType, got {type(provider_name_or_type).__name__}."
-             )
+                )
         
         provider = get_provider_from_provider_type(provider_type)
         if canonical_model_name != provider.canonical_model_name(canonical_model_name):
@@ -290,6 +293,64 @@ class EmbeddingReaderInterface:
         return tuple(
             {match.concept_id: match.similarity for match in matches_per_query}
             for matches_per_query in nearest_concepts
+        )
+    
+    def get_nearest_concepts_from_query_texts(
+        self,
+        session: Session,
+        index_type: IndexType,
+        query_texts: str | Tuple[str, ...] | List[str],
+        embedding_client: EmbeddingClient,
+        *,
+        metric_type: MetricType,
+        concept_filter: Optional[EmbeddingConceptFilter] = None,
+        batch_size: Optional[int] = None,
+    ):
+        """Return nearest stored concepts for query texts.
+
+        Convenience wrapper that embeds the query texts before performing
+        the nearest neighbor search.
+
+        Parameters
+        ----------
+        session : Session
+            SQLAlchemy session for any required relational access.
+        index_type : IndexType
+            The type of vector index used to store the embeddings.
+        query_texts : str | Tuple[str, ...] | List[str]
+            The text(s) to embed and search with.
+        metric_type : MetricType
+            The similarity or distance metric to use.
+        concept_filter : Optional[EmbeddingConceptFilter], optional
+            A filter to specify which concepts to consider.
+        batch_size : Optional[int], optional
+            Batch size for embedding generation.
+
+        Returns
+        -------
+        Tuple[Mapping[int, float], ...]
+            A tuple of dictionaries containing nearest concept matches.
+        """
+        if isinstance(query_texts, str):
+            query_texts = (query_texts,)
+        elif isinstance(query_texts, (list, tuple)):
+            query_texts = tuple(query_texts)
+        else:
+            raise ValueError(
+                f"Invalid type for query_texts: {type(query_texts)}. "
+                f"Expected str, list, or tuple."
+            )
+        query_embeddings = embedding_client.embeddings(
+            query_texts, 
+            batch_size=batch_size,
+            embedding_role=EmbeddingRole.QUERY,
+        )
+        return self.get_nearest_concepts(
+            session=session,
+            index_type=index_type,
+            query_embedding=query_embeddings,
+            metric_type=metric_type,
+            concept_filter=concept_filter,
         )
 
     def get_embeddings_by_concept_ids(
@@ -513,6 +574,7 @@ class EmbeddingWriterInterface(EmbeddingReaderInterface):
         self,
         texts: str | Tuple[str, ...] | List[str],
         *,
+        embedding_role: EmbeddingRole,
         batch_size: Optional[int] = None,
     ) -> np.ndarray:
         """Generate embeddings for texts.
@@ -529,7 +591,7 @@ class EmbeddingWriterInterface(EmbeddingReaderInterface):
         np.ndarray
             Embedding matrix of shape (n_texts, dimensions).
         """
-        return self._embedding_client.embeddings(texts, batch_size=batch_size)
+        return self._embedding_client.embeddings(texts, batch_size=batch_size, embedding_role=embedding_role)
 
     def upsert_concept_embeddings(
         self,
@@ -598,6 +660,7 @@ class EmbeddingWriterInterface(EmbeddingReaderInterface):
         embeddings = self.embed_texts(
             list(concept_texts),
             batch_size=batch_size,
+            embedding_role=EmbeddingRole.DOCUMENT,
         )
         self.upsert_concept_embeddings(
             session=session,
@@ -607,7 +670,7 @@ class EmbeddingWriterInterface(EmbeddingReaderInterface):
         )
         return embeddings
 
-    def get_nearest_concepts_by_texts(
+    def get_nearest_concepts_from_query_texts(
         self,
         session: Session,
         index_type: IndexType,
@@ -617,45 +680,12 @@ class EmbeddingWriterInterface(EmbeddingReaderInterface):
         concept_filter: Optional[EmbeddingConceptFilter] = None,
         batch_size: Optional[int] = None,
     ) -> Tuple[Mapping[int, float], ...]:
-        """Return nearest stored concepts for query texts.
-
-        Convenience wrapper that embeds the query texts before performing
-        the nearest neighbor search.
-
-        Parameters
-        ----------
-        session : Session
-            SQLAlchemy session for any required relational access.
-        index_type : IndexType
-            The type of vector index used to store the embeddings.
-        query_texts : str | Tuple[str, ...] | List[str]
-            The text(s) to embed and search with.
-        metric_type : MetricType
-            The similarity or distance metric to use.
-        concept_filter : Optional[EmbeddingConceptFilter], optional
-            A filter to specify which concepts to consider.
-        batch_size : Optional[int], optional
-            Batch size for embedding generation.
-
-        Returns
-        -------
-        Tuple[Mapping[int, float], ...]
-            A tuple of dictionaries containing nearest concept matches.
-        """
-        if isinstance(query_texts, str):
-            query_texts = (query_texts,)
-        elif isinstance(query_texts, (list, tuple)):
-            query_texts = tuple(query_texts)
-        else:
-            raise ValueError(
-                f"Invalid type for query_texts: {type(query_texts)}. "
-                f"Expected str, list, or tuple."
-            )
-        query_embeddings = self.embed_texts(query_texts, batch_size=batch_size)
-        return self.get_nearest_concepts(
+        return super().get_nearest_concepts_from_query_texts(
             session=session,
             index_type=index_type,
-            query_embedding=query_embeddings,
+            query_texts=query_texts,
+            embedding_client=self._embedding_client,
             metric_type=metric_type,
             concept_filter=concept_filter,
+            batch_size=batch_size,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from omop_emb.backends.faiss import FaissEmbeddingBackend
 from omop_emb.backends.pgvector import PGVectorEmbeddingBackend
 from omop_emb.interface import EmbeddingWriterInterface, EmbeddingReaderInterface
 from omop_emb.config import BackendType, ProviderType, IndexType
+from omop_emb.embeddings import EmbeddingRole
 
 
 TEST_DB_NAME = os.getenv("TEST_DATABASE_NAME", "test_omop_emb")
@@ -178,7 +179,11 @@ def mock_llm_client() -> Mock:
     mock_provider.provider_type = ProviderType.OLLAMA
     client.provider = mock_provider
 
-    def create_embeddings(concept_names: list[str] | str, batch_size: Optional[int] = None) -> np.ndarray:
+    def create_embeddings(
+        concept_names: list[str] | str,
+        embedding_role: EmbeddingRole,
+        batch_size: Optional[int] = None
+    ) -> np.ndarray:
         if isinstance(concept_names, str):
             concept_names = [concept_names]
         else:

--- a/tests/shared_backend_tests.py
+++ b/tests/shared_backend_tests.py
@@ -7,6 +7,7 @@ from omop_emb.config import IndexType, MetricType
 from omop_emb.utils.embedding_utils import EmbeddingConceptFilter
 from omop_emb.utils.errors import ModelRegistrationConflictError
 from omop_emb.backends import EmbeddingBackend
+from omop_emb.embeddings import EmbeddingRole
 from .conftest import CONCEPTS, MODEL_NAME, EMBEDDING_DIM, TEST_CONCEPT_EMB, PROVIDER_TYPE
 
 
@@ -90,7 +91,7 @@ class SharedBackendTests:
 
         test_concept = CONCEPTS["Hypertension"]
         concept_ids = (test_concept.concept_id,)
-        embeddings = mock_llm_client.embeddings(test_concept.concept_name)
+        embeddings = mock_llm_client.embeddings(test_concept.concept_name, embedding_role=EmbeddingRole.DOCUMENT)
 
         backend.upsert_embeddings(
             session=session,
@@ -115,7 +116,7 @@ class SharedBackendTests:
 
         test_concepts = [CONCEPTS["Hypertension"], CONCEPTS["Diabetes"]]
         concept_ids = [c.concept_id for c in test_concepts]
-        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts])
+        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts], embedding_role=EmbeddingRole.DOCUMENT)
 
         backend.upsert_embeddings(
             session=session,
@@ -149,7 +150,7 @@ class SharedBackendTests:
 
         test_concepts = list(CONCEPTS.values())
         concept_ids = [c.concept_id for c in test_concepts]
-        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts])
+        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts], embedding_role=EmbeddingRole.DOCUMENT)
 
         backend.upsert_embeddings(
             session=session,
@@ -160,7 +161,7 @@ class SharedBackendTests:
             embeddings=embeddings,
         )
 
-        query_embeddings = mock_llm_client.embeddings("Hypertension")
+        query_embeddings = mock_llm_client.embeddings("Hypertension", embedding_role=EmbeddingRole.QUERY)
         results = backend.get_nearest_concepts(
             session=session,
             model_name=MODEL_NAME,
@@ -187,7 +188,7 @@ class SharedBackendTests:
 
         test_concepts = list(CONCEPTS.values())
         concept_ids = [c.concept_id for c in test_concepts]
-        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts])
+        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts], embedding_role=EmbeddingRole.DOCUMENT)
 
         backend.upsert_embeddings(
             session=session,
@@ -223,7 +224,7 @@ class SharedBackendTests:
 
         test_concepts = list(CONCEPTS.values())
         concept_ids = [c.concept_id for c in test_concepts]
-        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts])
+        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts], embedding_role=EmbeddingRole.DOCUMENT)
 
         backend.upsert_embeddings(
             session=session,
@@ -260,7 +261,7 @@ class SharedBackendTests:
 
         test_concept = CONCEPTS["Hypertension"]
         concept_ids = (test_concept.concept_id,)
-        embeddings = mock_llm_client.embeddings(test_concept.concept_name)
+        embeddings = mock_llm_client.embeddings(test_concept.concept_name, embedding_role=EmbeddingRole.DOCUMENT)
 
         backend.upsert_embeddings(
             session=session,
@@ -301,7 +302,7 @@ class SharedBackendTests:
 
         test_concepts = list(CONCEPTS.values())
         concept_ids = [c.concept_id for c in test_concepts]
-        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts])
+        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts], embedding_role=EmbeddingRole.DOCUMENT)
 
         backend.upsert_embeddings(
             session=session,
@@ -358,7 +359,7 @@ class SharedBackendTests:
 
         test_concepts = list(CONCEPTS.values())
         concept_ids = [c.concept_id for c in test_concepts]
-        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts])
+        embeddings = mock_llm_client.embeddings([c.concept_name for c in test_concepts], embedding_role=EmbeddingRole.DOCUMENT)
 
         backend.upsert_embeddings(
             session=session,

--- a/tests/test_embedding_client.py
+++ b/tests/test_embedding_client.py
@@ -12,8 +12,9 @@ import numpy as np
 import pytest
 
 from omop_emb.config import ProviderType
-from omop_emb.embeddings import EmbeddingClient, OllamaProvider, OpenAIProvider
+from omop_emb.embeddings import EmbeddingClient, EmbeddingRole, OllamaProvider, OpenAIProvider
 from omop_emb.embeddings.embedding_client import EmbeddingClientError
+from omop_emb.config import ENV_DOCUMENT_EMBEDDING_PREFIX, ENV_QUERY_EMBEDDING_PREFIX
 
 OLLAMA_BASE = "http://localhost:11434/v1"
 OPENAI_BASE = "https://api.openai.com/v1"
@@ -156,26 +157,26 @@ class TestEmbeddings:
     def test_single_string_returns_2d_array(self, client):
         c, oi = client
         oi.embeddings.create.return_value = _make_embedding_response([[0.1, 0.2, 0.3]])
-        result = c.embeddings("hello")
+        result = c.embeddings("hello", embedding_role=EmbeddingRole.DOCUMENT)
         assert result.ndim == 2
         assert result.shape == (1, 3)
 
     def test_list_input_returns_correct_shape(self, client):
         c, oi = client
         oi.embeddings.create.return_value = _make_embedding_response([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]])
-        result = c.embeddings(["a", "b", "c"])
+        result = c.embeddings(["a", "b", "c"], embedding_role=EmbeddingRole.DOCUMENT)
         assert result.shape == (3, 2)
 
     def test_tuple_input_is_accepted(self, client):
         c, oi = client
         oi.embeddings.create.return_value = _make_embedding_response([[1.0, 0.0]])
-        result = c.embeddings(("only",))
+        result = c.embeddings(("only",), embedding_role=EmbeddingRole.DOCUMENT)
         assert result.shape == (1, 2)
 
     def test_values_preserved_in_output(self, client):
         c, oi = client
         oi.embeddings.create.return_value = _make_embedding_response([[1.0, 2.0]])
-        result = c.embeddings("text")
+        result = c.embeddings("text", embedding_role=EmbeddingRole.DOCUMENT)
         np.testing.assert_array_almost_equal(result[0], [1.0, 2.0])
 
     def test_batching_splits_texts_into_chunks(self, mock_openai):
@@ -187,7 +188,7 @@ class TestEmbeddings:
             _make_embedding_response([[1.0, 0.0], [0.0, 1.0]]),
             _make_embedding_response([[0.5, 0.5]]),
         ]
-        result = c.embeddings(["a", "b", "c"])
+        result = c.embeddings(["a", "b", "c"], embedding_role=EmbeddingRole.DOCUMENT)
         assert oi.embeddings.create.call_count == 2
         assert result.shape == (3, 2)
 
@@ -197,7 +198,7 @@ class TestEmbeddings:
             model=OLLAMA_MODEL, api_base=OLLAMA_BASE, embedding_batch_size=3, provider=OllamaProvider()
         )
         oi.embeddings.create.return_value = _make_embedding_response([[1.0], [2.0], [3.0]])
-        result = c.embeddings(["a", "b", "c"])
+        result = c.embeddings(["a", "b", "c"], embedding_role=EmbeddingRole.DOCUMENT)
         assert oi.embeddings.create.call_count == 1
         assert result.shape == (3, 1)
 
@@ -210,7 +211,7 @@ class TestEmbeddings:
             _make_embedding_response([[1.0]]),
             _make_embedding_response([[0.0]]),
         ]
-        result = c.embeddings(["a", "b"], batch_size=1)
+        result = c.embeddings(["a", "b"], embedding_role=EmbeddingRole.DOCUMENT, batch_size=1)
         assert oi.embeddings.create.call_count == 2
         assert result.shape == (2, 1)
 
@@ -223,7 +224,7 @@ class TestEmbeddings:
             _make_embedding_response([[1.0, 0.0]]),
             _make_embedding_response([[0.0, 1.0]]),
         ]
-        result = c.embeddings(["first", "second"])
+        result = c.embeddings(["first", "second"], embedding_role=EmbeddingRole.DOCUMENT)
         np.testing.assert_array_almost_equal(result[0], [1.0, 0.0])
         np.testing.assert_array_almost_equal(result[1], [0.0, 1.0])
 
@@ -289,7 +290,7 @@ class TestSimilarity:
     def test_string_inputs_trigger_embedding_calls(self, client):
         c, oi = client
         oi.embeddings.create.return_value = _make_embedding_response([[1.0, 0.0]])
-        c.similarity("foo", "bar")
+        c.similarity("foo", "bar", EmbeddingRole.QUERY, EmbeddingRole.DOCUMENT)
         assert oi.embeddings.create.call_count == 2
 
     def test_list_inputs_trigger_embedding_calls(self, client):
@@ -298,27 +299,29 @@ class TestSimilarity:
             _make_embedding_response([[1.0, 0.0], [0.0, 1.0]]),
             _make_embedding_response([[1.0, 0.0]]),
         ]
-        c.similarity(["a", "b"], ["c"])
+        c.similarity(["a", "b"], ["c"], EmbeddingRole.QUERY, EmbeddingRole.DOCUMENT)
         assert oi.embeddings.create.call_count == 2
 
     def test_array_inputs_bypass_embedding_calls(self, client):
         c, oi = client
         a = np.array([[1.0, 0.0]])
         b = np.array([[0.0, 1.0]])
-        c.similarity(a, b)
+        c.similarity(a, b, EmbeddingRole.QUERY, EmbeddingRole.DOCUMENT)
         oi.embeddings.create.assert_not_called()
 
     def test_array_inputs_return_correct_similarity(self, client):
         c, _ = client
         a = np.array([[1.0, 0.0]])
         b = np.array([[1.0, 0.0]])
-        np.testing.assert_almost_equal(c.similarity(a, b)[0, 0], 1.0)
+        np.testing.assert_almost_equal(
+            c.similarity(a, b, EmbeddingRole.QUERY, EmbeddingRole.DOCUMENT)[0, 0], 1.0
+        )
 
     def test_mixed_str_and_array_input(self, client):
         c, oi = client
         oi.embeddings.create.return_value = _make_embedding_response([[1.0, 0.0]])
         b = np.array([[1.0, 0.0]])
-        result = c.similarity("text", b)
+        result = c.similarity("text", b, EmbeddingRole.QUERY, EmbeddingRole.DOCUMENT)
         assert oi.embeddings.create.call_count == 1
         assert result.shape == (1, 1)
 
@@ -333,7 +336,7 @@ class TestEuclideanDistance:
         _, oi = mock_openai
         c = EmbeddingClient(model=OLLAMA_MODEL, api_base=OLLAMA_BASE, provider=OllamaProvider())
         oi.embeddings.create.return_value = _make_embedding_response([[1.0, 2.0, 3.0]])
-        assert c.euclidean_distance("hello", "hello") == pytest.approx(0.0)
+        assert c.euclidean_distance("hello", "hello", EmbeddingRole.QUERY, EmbeddingRole.QUERY) == pytest.approx(0.0)
 
     def test_known_3_4_5_distance(self, mock_openai):
         _, oi = mock_openai
@@ -342,13 +345,13 @@ class TestEuclideanDistance:
             _make_embedding_response([[0.0, 0.0]]),
             _make_embedding_response([[3.0, 4.0]]),
         ]
-        assert c.euclidean_distance("a", "b") == pytest.approx(5.0)
+        assert c.euclidean_distance("a", "b", EmbeddingRole.QUERY, EmbeddingRole.DOCUMENT) == pytest.approx(5.0)
 
     def test_returns_python_float(self, mock_openai):
         _, oi = mock_openai
         c = EmbeddingClient(model=OLLAMA_MODEL, api_base=OLLAMA_BASE, provider=OllamaProvider())
         oi.embeddings.create.return_value = _make_embedding_response([[1.0]])
-        assert isinstance(c.euclidean_distance("x", "x"), float)
+        assert isinstance(c.euclidean_distance("x", "x", EmbeddingRole.QUERY, EmbeddingRole.QUERY), float)
 
     def test_distance_is_symmetric(self, mock_openai):
         _, oi = mock_openai
@@ -359,8 +362,8 @@ class TestEuclideanDistance:
             _make_embedding_response([[0.0, 1.0]]),
             _make_embedding_response([[1.0, 0.0]]),
         ]
-        d_ab = c.euclidean_distance("a", "b")
-        d_ba = c.euclidean_distance("b", "a")
+        d_ab = c.euclidean_distance("a", "b", EmbeddingRole.QUERY, EmbeddingRole.DOCUMENT)
+        d_ba = c.euclidean_distance("b", "a", EmbeddingRole.DOCUMENT, EmbeddingRole.QUERY)
         assert d_ab == pytest.approx(d_ba)
 
 
@@ -380,3 +383,140 @@ class TestEmbeddingClientError:
     def test_preserves_message(self):
         with pytest.raises(EmbeddingClientError, match="something went wrong"):
             raise EmbeddingClientError("something went wrong")
+
+
+# ---------------------------------------------------------------------------
+# load_embedding_prefixes(): env var loading and startup logging
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestLoadEmbeddingPrefixes:
+    def test_returns_empty_strings_when_env_not_set(self, monkeypatch):
+        monkeypatch.delenv(ENV_DOCUMENT_EMBEDDING_PREFIX, raising=False)
+        monkeypatch.delenv(ENV_QUERY_EMBEDDING_PREFIX, raising=False)
+        doc_prefix, query_prefix = EmbeddingClient.load_embedding_prefixes()
+        assert doc_prefix == ""
+        assert query_prefix == ""
+
+    def test_returns_configured_prefixes(self, monkeypatch):
+        monkeypatch.setenv(ENV_DOCUMENT_EMBEDDING_PREFIX, "search_document: ")
+        monkeypatch.setenv(ENV_QUERY_EMBEDDING_PREFIX, "search_query: ")
+        doc_prefix, query_prefix = EmbeddingClient.load_embedding_prefixes()
+        assert doc_prefix == "search_document: "
+        assert query_prefix == "search_query: "
+
+    def test_logs_info_when_document_prefix_is_set(self, monkeypatch, caplog):
+        monkeypatch.setenv(ENV_DOCUMENT_EMBEDDING_PREFIX, "passage: ")
+        monkeypatch.delenv(ENV_QUERY_EMBEDDING_PREFIX, raising=False)
+        import logging
+        with caplog.at_level(logging.INFO, logger="omop_emb.embeddings.embedding_client"):
+            EmbeddingClient.load_embedding_prefixes()
+        assert any(
+            "passage: " in r.message and r.levelname == "INFO"
+            for r in caplog.records
+        )
+
+    def test_logs_info_when_query_prefix_is_set(self, monkeypatch, caplog):
+        monkeypatch.delenv(ENV_DOCUMENT_EMBEDDING_PREFIX, raising=False)
+        monkeypatch.setenv(ENV_QUERY_EMBEDDING_PREFIX, "search_query: ")
+        import logging
+        with caplog.at_level(logging.INFO, logger="omop_emb.embeddings.embedding_client"):
+            EmbeddingClient.load_embedding_prefixes()
+        assert any(
+            "search_query: " in r.message and r.levelname == "INFO"
+            for r in caplog.records
+        )
+
+    def test_logs_warning_when_document_prefix_not_set(self, monkeypatch, caplog):
+        monkeypatch.delenv(ENV_DOCUMENT_EMBEDDING_PREFIX, raising=False)
+        monkeypatch.delenv(ENV_QUERY_EMBEDDING_PREFIX, raising=False)
+        import logging
+        with caplog.at_level(logging.WARNING, logger="omop_emb.embeddings.embedding_client"):
+            EmbeddingClient.load_embedding_prefixes()
+        warning_messages = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any(ENV_DOCUMENT_EMBEDDING_PREFIX in m for m in warning_messages)
+
+    def test_logs_warning_when_query_prefix_not_set(self, monkeypatch, caplog):
+        monkeypatch.delenv(ENV_DOCUMENT_EMBEDDING_PREFIX, raising=False)
+        monkeypatch.delenv(ENV_QUERY_EMBEDDING_PREFIX, raising=False)
+        import logging
+        with caplog.at_level(logging.WARNING, logger="omop_emb.embeddings.embedding_client"):
+            EmbeddingClient.load_embedding_prefixes()
+        warning_messages = [r.message for r in caplog.records if r.levelname == "WARNING"]
+        assert any(ENV_QUERY_EMBEDDING_PREFIX in m for m in warning_messages)
+
+
+# ---------------------------------------------------------------------------
+# _apply_embedding_prefix(): prefix application per role
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestApplyEmbeddingPrefix:
+    @pytest.fixture
+    def client_with_prefixes(self, monkeypatch, mock_openai):
+        monkeypatch.setenv(ENV_DOCUMENT_EMBEDDING_PREFIX, "doc: ")
+        monkeypatch.setenv(ENV_QUERY_EMBEDDING_PREFIX, "query: ")
+        return EmbeddingClient(model=OLLAMA_MODEL, api_base=OLLAMA_BASE, provider=OllamaProvider())
+
+    @pytest.fixture
+    def client_no_prefixes(self, monkeypatch, mock_openai):
+        monkeypatch.delenv(ENV_DOCUMENT_EMBEDDING_PREFIX, raising=False)
+        monkeypatch.delenv(ENV_QUERY_EMBEDDING_PREFIX, raising=False)
+        return EmbeddingClient(model=OLLAMA_MODEL, api_base=OLLAMA_BASE, provider=OllamaProvider())
+
+    def test_document_prefix_prepended_to_string(self, client_with_prefixes):
+        c = client_with_prefixes
+        result = c._apply_embedding_prefix("Hypertension", text_role=EmbeddingRole.DOCUMENT)
+        assert result == "doc: Hypertension"
+
+    def test_query_prefix_prepended_to_string(self, client_with_prefixes):
+        c = client_with_prefixes
+        result = c._apply_embedding_prefix("high blood pressure", text_role=EmbeddingRole.QUERY)
+        assert result == "query: high blood pressure"
+
+    def test_document_and_query_produce_different_prefixed_texts(self, client_with_prefixes):
+        c = client_with_prefixes
+        doc = c._apply_embedding_prefix("Hypertension", text_role=EmbeddingRole.DOCUMENT)
+        query = c._apply_embedding_prefix("Hypertension", text_role=EmbeddingRole.QUERY)
+        assert doc != query
+
+    def test_prefix_applied_to_all_items_in_tuple(self, client_with_prefixes):
+        c = client_with_prefixes
+        result = c._apply_embedding_prefix(("a", "b"), text_role=EmbeddingRole.DOCUMENT)
+        assert result == ("doc: a", "doc: b")
+
+    def test_prefix_applied_to_all_items_in_list(self, client_with_prefixes):
+        c = client_with_prefixes
+        result = c._apply_embedding_prefix(["a", "b"], text_role=EmbeddingRole.DOCUMENT)
+        assert result == ["doc: a", "doc: b"]
+
+    def test_no_prefix_returns_texts_unchanged_string(self, client_no_prefixes):
+        c = client_no_prefixes
+        result = c._apply_embedding_prefix("Hypertension", text_role=EmbeddingRole.DOCUMENT)
+        assert result == "Hypertension"
+
+    def test_no_prefix_returns_texts_unchanged_list(self, client_no_prefixes):
+        c = client_no_prefixes
+        result = c._apply_embedding_prefix(["a", "b"], text_role=EmbeddingRole.QUERY)
+        assert result == ["a", "b"]
+
+    def test_prefix_reflected_in_api_call(self, monkeypatch, mock_openai):
+        """Verify the prefixed text reaches the OpenAI API call."""
+        _, oi = mock_openai
+        monkeypatch.setenv(ENV_DOCUMENT_EMBEDDING_PREFIX, "passage: ")
+        monkeypatch.delenv(ENV_QUERY_EMBEDDING_PREFIX, raising=False)
+        c = EmbeddingClient(model=OLLAMA_MODEL, api_base=OLLAMA_BASE, provider=OllamaProvider())
+        oi.embeddings.create.return_value = _make_embedding_response([[0.1, 0.2]])
+        c.embeddings("diabetes", embedding_role=EmbeddingRole.DOCUMENT)
+        call_input = oi.embeddings.create.call_args.kwargs["input"]
+        assert call_input == ("passage: diabetes",)
+
+    def test_no_prefix_passes_text_verbatim_to_api(self, monkeypatch, mock_openai):
+        _, oi = mock_openai
+        monkeypatch.delenv(ENV_DOCUMENT_EMBEDDING_PREFIX, raising=False)
+        monkeypatch.delenv(ENV_QUERY_EMBEDDING_PREFIX, raising=False)
+        c = EmbeddingClient(model=OLLAMA_MODEL, api_base=OLLAMA_BASE, provider=OllamaProvider())
+        oi.embeddings.create.return_value = _make_embedding_response([[0.1, 0.2]])
+        c.embeddings("diabetes", embedding_role=EmbeddingRole.DOCUMENT)
+        call_input = oi.embeddings.create.call_args.kwargs["input"]
+        assert call_input == ("diabetes",)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -4,6 +4,7 @@ import pytest
 import sqlalchemy as sa
 from omop_alchemy.cdm.model.vocabulary import Concept
 from .conftest import CONCEPTS, EMBEDDING_DIM
+from omop_emb.embeddings import EmbeddingRole
 
 
 @pytest.mark.unit
@@ -54,8 +55,8 @@ class TestFixtures:
     
     def test_mock_llm_client_generates_embeddings(self, mock_llm_client):
         """Verify mock LLM client generates consistent embeddings."""
-        emb1 = mock_llm_client.embeddings(CONCEPTS["Hypertension"].concept_name)
-        emb2 = mock_llm_client.embeddings(CONCEPTS["Hypertension"].concept_name)
+        emb1 = mock_llm_client.embeddings(CONCEPTS["Hypertension"].concept_name, embedding_role=EmbeddingRole.DOCUMENT)
+        emb2 = mock_llm_client.embeddings(CONCEPTS["Hypertension"].concept_name, embedding_role=EmbeddingRole.DOCUMENT)
         
         # Should be deterministic
         assert (emb1 == emb2).all()

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -5,6 +5,7 @@ import numpy as np
 from unittest.mock import Mock
 
 from omop_emb.interface import EmbeddingWriterInterface
+from omop_emb.embeddings import EmbeddingRole
 from omop_emb.utils.embedding_utils import EmbeddingConceptFilter
 from omop_emb.config import IndexType, MetricType
 from omop_emb.backends.base import NearestConceptMatch
@@ -52,7 +53,7 @@ class TestInterface:
 
     def test_embed_texts(self, embedding_writer_interface: EmbeddingWriterInterface):
         """Test embedding generation."""
-        embeddings = embedding_writer_interface.embed_texts(CONCEPTS["Hypertension"].concept_name)
+        embeddings = embedding_writer_interface.embed_texts(CONCEPTS["Hypertension"].concept_name, embedding_role=EmbeddingRole.DOCUMENT)
 
         assert embeddings.shape == (1, EMBEDDING_DIM)
         assert embeddings.dtype == np.float32
@@ -60,7 +61,7 @@ class TestInterface:
     def test_embed_multiple_texts(self, embedding_writer_interface: EmbeddingWriterInterface):
         """Test embedding multiple texts."""
         texts = [c.concept_name for c in CONCEPTS.values()]
-        embeddings = embedding_writer_interface.embed_texts(texts)
+        embeddings = embedding_writer_interface.embed_texts(texts, embedding_role=EmbeddingRole.DOCUMENT)
 
         assert embeddings.shape == (len(texts), EMBEDDING_DIM)
 


### PR DESCRIPTION
Adds task-specific prefix support for asymmetric embedding models (nomic-embed-text, E5, BGE) that require different prefixes for indexing versus querying. Without this, models like `nomic-embed-text` silently return degraded similarity scores.

## Attribution

These changes were inspired by and adapted from the work of @rkboyce in their original PR #7. This PR constitutes the changes outlined as [here](https://github.com/AustralianCancerDataNetwork/omop-emb/pull/7#issuecomment-4293987424)

> - **Model Support**: Prefix support for asymmetric embedding models.

## Changes

### `EmbeddingClient`:

- `EmbeddingRole` enum (`DOCUMENT`, `QUERY`) added to represent the two roles
- `embeddings()` now requires an explicit `embedding_role` argument
- `_apply_embedding_prefix()` prepends the role-specific prefix before the API call
- `load_embedding_prefixes()` reads `OMOP_EMB_DOCUMENT_EMBEDDING_PREFIX` and `OMOP_EMB_QUERY_EMBEDDING_PREFIX` at construction time; logs `INFO` when a prefix is active, `WARNING` with actionable guidance when unset
- `similarity()` requires roles for `terms` and `terms_to_match`
- `euclidean_distance()` requires roles for `text1` and `text2`

### `EmbeddingWriterInterface`:

- `embed_and_upsert_concepts` hardcodes `EmbeddingRole.DOCUMENT`
- `embed_texts` exposes `embedding_role` to the caller
- `get_nearest_concepts_from_query_texts` hardcodes `EmbeddingRole.QUERY`

## Documentation

- New page: `usage/asymmetric-embeddings.md` covering what asymmetric models are, why prefixes matter for OMOP concept search, per-model prefix examples, and which API entry points handle roles automatically versus requiring explicit caller input
- `index.md`: added Environment Variables reference table linking all five vars to their detail pages
- `interface-guide.md`: fixed `embed_texts` code example, added admonition linking to the new page
- `README.md`: added the two prefix vars to Runtime Configuration with example values

## Tests

- Updated all existing `embeddings()` and `similarity()` / `euclidean_distance()` calls to pass explicit roles
- `TestLoadEmbeddingPrefixes`: env var loading, INFO log when set, WARNING log when unset
- `TestApplyEmbeddingPrefix`: prefix application for string/tuple/list inputs, role differentiation, end-to-end verification that prefixed text reaches the API call