### PR TITLE
Support KnowledgeResource of oa-configurator

### DIFF
--- a/src/omop_emb/config.py
+++ b/src/omop_emb/config.py
@@ -7,7 +7,7 @@ from typing import ClassVar, Dict, Tuple
 
 from pydantic import Field
 from sqlalchemy import Engine
-from oa_configurator import DatabaseConfig, PackageConfigBase, ResourceSpec
+from oa_configurator import DatabaseConfig, PackageConfigBase, ResourceKind, ResourceSpec
 
 from omop_alchemy.config import OmopAlchemyConfig
 
@@ -36,8 +36,7 @@ class OmopEmbConfig(PackageConfigBase):
         display_name="Embedding Database",
         description="pgvector database for storing OMOP concept embeddings.",
         connection_name_hint="emb",
-        cdm_schema_default="public",
-        is_cdm_database=False,
+        resource_kind=ResourceKind.embedding,
     )
     TEST_DB: ClassVar[ResourceSpec] = ResourceSpec(
         semantic_name="test_emb_db",
@@ -46,8 +45,7 @@ class OmopEmbConfig(PackageConfigBase):
             "Dedicated PostgreSQL/pgvector database for running omop-emb integration tests."
         ),
         connection_name_hint="pg_test_emb",
-        is_cdm_database=False,
-        cdm_schema_default="public",
+        resource_kind=ResourceKind.embedding,
         connection_defaults=DatabaseConfig(
             dialect="postgresql+psycopg",
             host="localhost",


### PR DESCRIPTION
Depends on the following items to pass:
- [`oa-configurator`](https://github.com/AustralianCancerDataNetwork/oa-configurator/pull/11)
- [`OMOP_Alchemy`](https://github.com/AustralianCancerDataNetwork/OMOP_Alchemy/pull/34)

Adapted structure of the internal configuration to include `ResourceKind` in the configuration to switch between CDM resources and other resources for future adaptability. Also has the setting to set an embedding database `ResourceKind` to differentiate further to the CDM resource.

### Note
Requires  the two items from above to pass and be released on PyPI