### PR TITLE
Fix CI by granting correct permissions

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
 permissions:
   contents: write
+  pull-requests: read
 jobs:
   draft:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
## Summary

Specifying any `permissions` key at the workflow level sets all unmentioned scopes to `none`. `release-drafter` needs `pull-requests: read` to read PR labels and titles for the changelog.


Follow-up of #39 
